### PR TITLE
Dev - layer_name_igo dans le mapfile (pour la rétro à Luc)

### DIFF
--- a/pilotage/app/controllers/CRUD/IgoCoucheController.php
+++ b/pilotage/app/controllers/CRUD/IgoCoucheController.php
@@ -178,7 +178,8 @@ class IgoCoucheController extends ControllerBase {
     public function saveAction($r_controller = null, $r_action = null, $r_id = null){
         
         $this->setGeometrieDesc();
-        parent::saveAction($r_controller = null, $r_action = null, $r_id = null);
+        //parent::saveAction($r_controller = null, $r_action = null, $r_id = null);
+        parent::saveAction(null, null, null);
         
     }
 
@@ -219,18 +220,6 @@ class IgoCoucheController extends ControllerBase {
             }
         }
     }
-/*
-    public function saveAction($r_controller = null, $r_action = null, $r_id = null) {
-        parent::saveAction($r_controller, $r_action, $r_id);
-        $couche_id = $this->request->getPost("id");
-        $couche = IgoCouche::findFirstById($couche_id);
-        if (!$couche) {
-            throw new Exception("Couche inexistante");
-        }
-        $couche->save();
-        
-         
-    }*/
     
     function transform($xml, $xsl) {
         $xslt = new XSLTProcessor();

--- a/pilotage/app/controllers/MapfileParser/MapfileParser.php
+++ b/pilotage/app/controllers/MapfileParser/MapfileParser.php
@@ -72,11 +72,11 @@ class MapfileParser {
                 $mapParameters = array(
                     "projection"
                 );
-
+                
                 foreach ($mapMetaData as $metaData) {
                     $m[$metaData] = $map->getMeta($metaData);
                 }
-
+             
                 foreach ($mapParameters as $parameter) {
                     $m[$parameter] = $map->getParam($parameter);
                 }

--- a/pilotage/app/controllers/MapfileParser/core/inc/map.inc.php
+++ b/pilotage/app/controllers/MapfileParser/core/inc/map.inc.php
@@ -78,7 +78,8 @@ class Map{
             "ows_exclude_items",
             "ows_include_items",
             "msp_classe_meta",
-            "wms_attribution_title"
+            "wms_attribution_title",
+            "layer_name_igo"
         );
 
         $layerZIndex = array(
@@ -101,7 +102,7 @@ class Map{
         for($i = 0; $i < $this->oMap->numlayers; $i++){
             //create new layer object
             $layer = new Layer($this->oMap->getLayer($i));
-
+            
             //Create new empty hash array to store layer data
             $l = array();
 
@@ -113,6 +114,10 @@ class Map{
             //Get some metadata
             foreach ($layerMetaData as $metaData) {
                 $l[$metaData] = $layer->getMeta($metaData);
+                //Utiliser le layer name destiné à l'usage de IGO au besoin
+                if($metaData == "layer_name_igo"){
+                    $l['name'] = $l[$metaData];
+                }
             }
             //Get other parameters as plain text
             $l['layer_def'] = $layer->getLayerDef($layerParameters);
@@ -137,7 +142,7 @@ class Map{
             $l['zIndex'] = $index;            
             $layers[] = $l;
         }
-
+        
         return $layers;
     }
 }

--- a/pilotage/app/sql/creation_de_tables.sql
+++ b/pilotage/app/sql/creation_de_tables.sql
@@ -1134,10 +1134,14 @@ CREATE OR REPLACE VIEW igo_vue_contexte_couche_navigateur AS
             cgr.parent_groupe_id,
             cc.est_active,
                     igo_couche.est_fond_de_carte,
-                CASE
-                    WHEN igo_couche.est_fond_de_carte THEN igo_couche.mf_layer_name::text
-                    ELSE concat(igo_couche.mf_layer_name, '_', cgr.parent_groupe_id)
-                END AS mf_layer_name,
+             CASE
+	    WHEN igo_couche.est_fond_de_carte 
+		THEN igo_couche.mf_layer_name::text
+	    WHEN cgr.parent_groupe_id is null
+			THEN igo_couche.mf_layer_name
+	    ELSE 
+	    concat(igo_couche.mf_layer_name, '_', cgr.parent_groupe_id)
+	END AS mf_layer_name,
             COALESCE(cc.mf_layer_meta_name, igo_couche.mf_layer_meta_name) AS mf_layer_meta_name2,
                     igo_couche.mf_layer_meta_name,
             cc.mf_layer_meta_title AS mf_layer_meta_title2,

--- a/pilotage/app/views/igo_contexte/mapfile.volt
+++ b/pilotage/app/views/igo_contexte/mapfile.volt
@@ -46,7 +46,6 @@ MAP
     {% if couche.ind_data and (couche.est_visible or couche.est_active) %}
             LAYER
                     NAME "{{couche.mf_layer_name}}"
-                    IGO_NAME "{{couche.mf_layer_name_original}}"
                     TYPE {{couche.IgoCouche.IgoGeometrie.IgoGeometrieType.layer_type}}
 
                     GROUP "{{couche.mf_layer_group}}"
@@ -76,6 +75,7 @@ MAP
                     {% endif  %}
 
                     METADATA
+                            "layer_name_igo" "{{couche.mf_layer_name_igo}}"
                             "wms_group_title"      "{{ couche.mf_layer_meta_group_title}}"
                             "wms_name"             "{{ couche.mf_layer_meta_name}}"
                             "wms_title"            "{{ couche.mf_layer_meta_title}}"

--- a/pilotage/app/views/igo_contexte/mapfile.volt
+++ b/pilotage/app/views/igo_contexte/mapfile.volt
@@ -46,6 +46,7 @@ MAP
     {% if couche.ind_data and (couche.est_visible or couche.est_active) %}
             LAYER
                     NAME "{{couche.mf_layer_name}}"
+                    IGO_NAME "{{couche.mf_layer_name_original}}"
                     TYPE {{couche.IgoCouche.IgoGeometrie.IgoGeometrieType.layer_type}}
 
                     GROUP "{{couche.mf_layer_group}}"


### PR DESCRIPTION
Au lieu de IGO_NAME dans le LAYER (déclenchait une erreur dans le mapfile parser), on a layer_name_igo d'ajouté dans les metadata.

Il est nécessaire de refaire le create view de vue igo_vue_contexte_couche_navigateur
