### PR TITLE
Retro config

### DIFF
--- a/config/config.exemple.php
+++ b/config/config.exemple.php
@@ -45,7 +45,8 @@ return array(
             'libraryDir'     => $basePilotageDir . 'app/library/',
             'cacheDir'       => $basePilotageDir . 'app/cache/',
             'helpersDir'     => $basePilotageDir . 'app/helpers/',
-            'validatorsDir'  => $basePilotageDir . 'app/validators/'  // Temporaire, TODO refactor de validator dans services.
+            'validatorsDir'  => $basePilotageDir . 'app/validators/',  // Temporaire, TODO refactor de validator dans services.
+            'retroCheminDefaut' => '' //Chemin serveur où sont les mapfile pour la rétroingénierie
         ),
         'edition' => array(
             'fieldsDir' => $baseEditionDir . 'app/fields/',

--- a/pilotage/app/controllers/MapfileController.php
+++ b/pilotage/app/controllers/MapfileController.php
@@ -42,7 +42,7 @@ class MapfileController extends ControllerBase {
         if ($this->session->get('mapfile')) {
             $this->view->mapfile = $this->session->get('mapfile');
         } else {
-            $this->view->mapfile = '/srv/www/geomatique/services/map/wms/gouvouvertqc.map';
+            $this->view->mapfile = $this->getDI()->getConfig()->application->pilotage->retroCheminDefaut;
         }
     }
 


### PR DESCRIPTION
Le chemin par défaut pour la rétro d'un mapfile est maintenant dans le fichier de config au lieu d'être codé en dur.
