### PR TITLE
Fixed puppet-igo version

### DIFF
--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -6,7 +6,7 @@ mod 'apache',
 
 mod 'igo',
   :git => 'https://github.com/infra-geo-ouverte/puppet-igo.git',
-  :ref => '1.1.0'
+  :ref => '1.1.1'
 
 mod 'ntp',
   :git => 'https://github.com/puppetlabs/puppetlabs-ntp.git',


### PR DESCRIPTION
 Updated to 1.1.1 to use igo-lib git depot
