### PR TITLE
 Ajout InfoDeclencheur InfoUrl, meilleur gestion erreur

### DIFF
--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1330,11 +1330,11 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |groupe	| Groupe auquel appartient la couche dans l’arborescence| Non	| Chaîne alphanumérique	|		|
 |visible| Indique si la couche doit être affichée dans l'arborescence| Non| Booléen		| *true*	|
 |active | Indique si la couche doit être affichée sur la carte au démarrage du navigateur| Non| Booléen| *false*|
-|infoFormat | Indique le format voulu pour un GetFeatureInfo qui doit être affichée dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
-|infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour un GetFeatureInfo sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
-|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur le GettFeatureInfo après le clique sur la couche dans la carte | Non|  URL|		|
-|infoUrl | Indique un url qui sera remplacer par l'url du GettFeatureInfo| Non| URL| |
-|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GettFeatureInfo après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
+|infoFormat | Indique le format voulu pour l' *OutilInfo* qui sera affiché dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
+|infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
+|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
+|infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
+|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GettFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
 |opacite| Transparence de la couche 			| Non		| Nombre décimal entre 0 et 100| *1*	|
 |ordreAffichage| Ordre d'affichage de la couche		| Non		| Nombre entier		| *Valeurs par défaut d’OpenLayers*|
 |droit	| Indique les droits de la couche (Copyrights)	| Non		| Chaîne alphanumérique	| 		|

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1334,7 +1334,7 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
 |infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
 |infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
-|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GettFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
+|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
 |opacite| Transparence de la couche 			| Non		| Nombre décimal entre 0 et 100| *1*	|
 |ordreAffichage| Ordre d'affichage de la couche		| Non		| Nombre entier		| *Valeurs par défaut d’OpenLayers*|
 |droit	| Indique les droits de la couche (Copyrights)	| Non		| Chaîne alphanumérique	| 		|
@@ -1496,9 +1496,6 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |titre	|Titre de la couche			|Non	|Chaîne alphanumérique|*Valeur de l’attribut nom*|
 |extraParams|Paramètres supplémentaires à spécifier lors de l’appel au service de carte|Non|Chaîne alphanumérique||
 |mapdir	|Chemin du mapfile à utiliser (dans le cas d’un service de carte publié avec MapServer)|Non (sauf dans le cas d’un service de carte publié avec MapServer)|Chaîne alphanumérique||
-|infoFormat|Spécifier le format du GetFeatureInfo disponible pour la couche WMS|Non    |*html*,*xml*,*gml*,*gml311*||
-|infoEncodage|Spécifier l'encodage de la couche WMS|Non |Chaîne alphanumérique||
-|infoGabarit|Indiquer l'emplacement d'un gabarit personnalisé|Non|Chaîne alphanumérique||
 |impressionURL|URL du service de la carte|Non   |URL||
 |mode|Intégrer l'ensemble des couches d'un service WMS|Non  |*getCapabilities*||
 *Exemples*

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1330,7 +1330,7 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |groupe	| Groupe auquel appartient la couche dans l’arborescence| Non	| Chaîne alphanumérique	|		|
 |visible| Indique si la couche doit être affichée dans l'arborescence| Non| Booléen		| *true*	|
 |active | Indique si la couche doit être affichée sur la carte au démarrage du navigateur| Non| Booléen| *false*|
-|infoFormat | Indique le format voulu pour un GetFeatureInfo qui doit être affichée dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| Chaîne alphanumérique| *gml*,*gml311*,*xml*,*html*|
+|infoFormat | Indique le format voulu pour un GetFeatureInfo qui doit être affichée dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour un GetFeatureInfo sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
 |infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur le GettFeatureInfo après le clique sur la couche dans la carte | Non|  URL|		|
 |infoUrl | Indique un url qui sera remplacer par l'url du GettFeatureInfo| Non| URL| |

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1330,11 +1330,6 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |groupe	| Groupe auquel appartient la couche dans l’arborescence| Non	| Chaîne alphanumérique	|		|
 |visible| Indique si la couche doit être affichée dans l'arborescence| Non| Booléen		| *true*	|
 |active | Indique si la couche doit être affichée sur la carte au démarrage du navigateur| Non| Booléen| *false*|
-|infoFormat | Indique le format voulu pour l' *OutilInfo* qui sera affiché dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
-|infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
-|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
-|infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
-|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
 |opacite| Transparence de la couche 			| Non		| Nombre décimal entre 0 et 100| *1*	|
 |ordreAffichage| Ordre d'affichage de la couche		| Non		| Nombre entier		| *Valeurs par défaut d’OpenLayers*|
 |droit	| Indique les droits de la couche (Copyrights)	| Non		| Chaîne alphanumérique	| 		|
@@ -1498,6 +1493,12 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |mapdir	|Chemin du mapfile à utiliser (dans le cas d’un service de carte publié avec MapServer)|Non (sauf dans le cas d’un service de carte publié avec MapServer)|Chaîne alphanumérique||
 |impressionURL|URL du service de la carte|Non   |URL||
 |mode|Intégrer l'ensemble des couches d'un service WMS|Non  |*getCapabilities*||
+|infoFormat | Indique le format voulu pour l' *OutilInfo* qui sera affiché dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
+|infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
+|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
+|infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
+|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
+
 *Exemples*
 ```xml
 <couche url="http://ows.geobase.ca/wms/geobase\_en?" nom="nrwn:track"

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1330,6 +1330,11 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |groupe	| Groupe auquel appartient la couche dans l’arborescence| Non	| Chaîne alphanumérique	|		|
 |visible| Indique si la couche doit être affichée dans l'arborescence| Non| Booléen		| *true*	|
 |active | Indique si la couche doit être affichée sur la carte au démarrage du navigateur| Non| Booléen| *false*|
+|infoFormat | Indique le format voulu pour un GetFeatureInfo qui doit être affichée dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| Chaîne alphanumérique| *gml*,*gml311*,*xml*,*html*|
+|infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour un GetFeatureInfo sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
+|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur le GettFeatureInfo après le clique sur la couche dans la carte | Non|  URL|		|
+|infoUrl | Indique un url qui sera remplacer par l'url du GettFeatureInfo| Non| URL| |
+|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GettFeatureInfo après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
 |opacite| Transparence de la couche 			| Non		| Nombre décimal entre 0 et 100| *1*	|
 |ordreAffichage| Ordre d'affichage de la couche		| Non		| Nombre entier		| *Valeurs par défaut d’OpenLayers*|
 |droit	| Indique les droits de la couche (Copyrights)	| Non		| Chaîne alphanumérique	| 		|

--- a/interfaces/navigateur/public/js/app/outil/outilInfo.js
+++ b/interfaces/navigateur/public/js/app/outil/outilInfo.js
@@ -8,7 +8,7 @@
  * @version 1.0
  */
 
-define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect) {
+define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, BrowserDetect, Point) {
 
     /** 
      * Création de l'object Outil.OutilInfo.
@@ -62,7 +62,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
         this.activerEvent();
         this.carte.controles.activerClique();
         this.activerToggleItem();
-        
+
         this.couchesInterroger = [];
         this.features = [];
         this.featuresHbars = [];
@@ -86,40 +86,40 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
         this.erreurs = 0;
         this.px;
     };
-  
+
     OutilInfo.prototype.cliqueCarte = function (e) {
-       
+
         var lonlat = e.point._obtenirLonLatOL();
         this.px = this.carte._carteOL.getViewPortPxFromLonLat(lonlat);
 
         //Appeller la fonction pour obtenir les couche interrogable
         this.couchesInterroger = this.obtCouchesInterrogable();
-    
-        if (this.couchesInterroger.length == 0) {
+
+        if (this.couchesInterroger.length === 0) {
             // TODO : this is HARDCODED
             var szErrMsg = "Veuillez sélectionner au moins une couche avant d'effectuer une requête.";
             Aide.afficherMessage("Outil Information", szErrMsg, "OK", "Info");
             return;
         }
-        
+
         //Appller la fonction pour obtenir les gabarit Handlebars pour les couche qui en ont
         this.obtCouchesHbars(this.couchesInterroger);
-    }
+    };
 
- OutilInfo.prototype.obtCouchesInterrogable = function () {
+    OutilInfo.prototype.obtCouchesInterrogable = function () {
         var that = this;
         var couchesInterrogable = [];
         var couches = that.carte.gestionCouches.obtenirCouchesParType('WMS', true);
 
         for (var l = 0; l < couches.length; ++l) {
             var couche = couches[l];
-          
+
             couche.options.estInterrogable = couche._layer.queryable;
 
-           //Seule les couche activ qui sont pas des fond de carte
-           //qui sont queryable, visible et inrange
+            //Seule les couche activ qui sont pas des fond de carte
+            //qui sont queryable, visible et inrange
             if (couche.estActive() && !couche.estFond() &&
-                    couche._layer.getVisibility() && couche._layer.calculateInRange() && 
+                    couche._layer.getVisibility() && couche._layer.calculateInRange() &&
                     couche._layer.queryable && couche._layer.inRange) {
 
                 couchesInterrogable.push({
@@ -128,6 +128,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                     'infoFormat': couche.options.infoFormat,
                     'infoEncodage': couche.options.infoEncodage,
                     'infoDeclencheur': couche.options.infoDeclencheur,
+                    'infoUrl': couche.options.infoUrl,
                     'infoGabarit': couche.options.infoGabarit,
                     'estInterrogable': couche.options.estInterrogable,
                     'url': couche.options.url,
@@ -137,34 +138,45 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                 });
             }
         }
-        
+
         //On fait trier pour faire les appels ajax dans un ordre logique gml,xml et html ensuite Hbars
-        couchesInterrogable.sort(function (a ) {
-            return (a.infoFormat == "html" ? 1 :
-                    a.infoFormat == "gml" ? -1 : 
-                    a.infoFormat == "gml311" ? -1 : 
-                    a.infoFormat == "xml" ? -1 : 0);
+        couchesInterrogable.sort(function (a) {
+            return (a.infoFormat === "html" ? 1 :
+                    a.infoFormat === "gml" ? -1 :
+                    a.infoFormat === "gml311" ? -1 :
+                    a.infoFormat === "xml" ? -1 : 0);
         });
-        
+
         return couchesInterrogable;
     };
 
+    OutilInfo.prototype.formatUrl = function (url, args) {
+
+        var s = url,
+                i = args.length + 1;
+        while (i--) {
+            s = s.replace(new RegExp('\\{' + i + '\\}', 'gm'), args[i]);
+        }
+        //Caractère de remplacement pour QS '&' pas permis dans xml de context
+        s = s.replace(/\$/g, '&');
+        return s;
+    };
 
 
- OutilInfo.prototype.obtCouchesHbars = function (couches) {
+    OutilInfo.prototype.obtCouchesHbars = function (couches) {
         var that = this;
-       
+
         //On va chercher tous les templates nécessaires pour faire un seul require
         var doitRequire = [];
         for (var d = 0; d < couches.length; ++d) {
-            var couche = couches[d];  
+            var couche = couches[d];
             if (couche.infoGabarit !== undefined && couche.infoGabarit.substring(couche.infoGabarit.lastIndexOf(".")) !== ".xsl") {
                 doitRequire.push('hbars!' + couche.infoGabarit);
             }
         }
 
         var i = 0;
-      
+
         require(doitRequire, function () {
             for (var c = 0; c < couches.length; ++c) {
                 var couche = couches[c];
@@ -175,30 +187,62 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                 };
             }
 
+            //Appller la fonction pour obtenir les declencheures pour les couche qui en ont
+            that.obtCouchesDeclencheur(couches);
+        });
+    };
+
+    OutilInfo.prototype.obtCouchesDeclencheur = function (couches) {
+        var that = this;
+
+        //On va chercher tous les declencheur nécessaires pour faire un seul require
+        var doitRequire = [];
+        for (var d = 0; d < couches.length; ++d) {
+            var couche = couches[d];
+            if (couche.infoDeclencheur !== undefined) {
+                doitRequire.push(couche.infoDeclencheur + '.js');
+            }
+        }
+
+        var i = 0;
+
+        require(doitRequire, function () {
+            for (var c = 0; c < couches.length; ++c) {
+                var couche = couches[c];
+                //On obtient toutes les couches avec un gabarit 
+                if (couche.infoDeclencheur !== undefined) {
+                    couche._declencheur = arguments[i];
+                    i++;
+                };
+            }
+
             //Appeler la fonction pour le traitement ajax
             that.appelerGetInfo(couches);
+
         });
     };
 
     OutilInfo.prototype.appelerGetInfo = function (couchesInterroger) {
         var that = this;
         var jqXHRs = [];
-        
+
         for (var j = 0; j < couchesInterroger.length; j++) {
             var oCoucheObtnInfo = couchesInterroger[j];
             var nomCoucheLegende = oCoucheObtnInfo.titre;
             var Template = oCoucheObtnInfo._template;
+            var Declencheur = oCoucheObtnInfo._declencheur;
 
             var coucheInfoFormat;
+
             var coucheDataType;
             var encodage;
             var xslTemplate;
-       
+
             switch (oCoucheObtnInfo.infoFormat)
             {
                 case "html":
                     coucheInfoFormat = "text/html";
-                    coucheDataType = "html"; 
+                    coucheDataType = "html";
                     break;
                 case "gml":
                     coucheInfoFormat = "application/vnd.ogc.gml";
@@ -219,48 +263,75 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             }
 
             //Exceptionellement IE on doit passer par le proxy pour encodage
-            if (BrowserDetect.browser == "Explorer") {
+            if (BrowserDetect.browser === "Explorer") {
                 encodage = (oCoucheObtnInfo.infoEncodage === undefined) ? 'UTF-8' : encodage;
             }
-            
+
             //Appliquer un xsl ESRI
-             if (oCoucheObtnInfo.infoGabarit !== undefined && oCoucheObtnInfo.infoGabarit.substring(oCoucheObtnInfo.infoGabarit.lastIndexOf(".")) === ".xsl" ) {
+            if (oCoucheObtnInfo.infoGabarit !== undefined && oCoucheObtnInfo.infoGabarit.substring(oCoucheObtnInfo.infoGabarit.lastIndexOf(".")) === ".xsl") {
                 xslTemplate = oCoucheObtnInfo.infoGabarit;
             }
 
-            jqXHRs.push($.ajax({
-                url: Aide.utiliserProxy(decodeURIComponent(oCoucheObtnInfo.url)),
-                data: {
-                    LAYERS: oCoucheObtnInfo.nom,
-                    SERVICE: 'WMS',
-                    REQUEST: "GetFeatureInfo",
-                    EXCEPTIONS: "application/vnd.ogc.se_xml",
-                    VERSION: oCoucheObtnInfo.version,
-                    SRS: this.carte._carteOL.getProjection(),
-                    BBOX: this.carte._carteOL.getExtent().toBBOX(),
-                    QUERY_LAYERS: oCoucheObtnInfo.nom,
-                    X: Math.floor(this.px.x),
-                    Y: Math.floor(this.px.y),
-                    INFO_FORMAT: coucheInfoFormat,
-                    FEATURE_COUNT: 100,
-                    WIDTH: this.carte._carteOL.size.w,
-                    HEIGHT: this.carte._carteOL.size.h,
-                    _encodage: encodage,
-                    xsl_template: xslTemplate
-                },
-                context: this,
-                dataType: coucheDataType,
-                beforeSend: function (jqXHR) {
-                    if (oCoucheObtnInfo.infoEncodage !== undefined) {
-                        if (jqXHR.overrideMimeType) {
-                            jqXHR.overrideMimeType(coucheInfoFormat + "; charset=" + oCoucheObtnInfo.infoEncodage);
-                        }
-                    }
-                },
-                success: this.traiterRetourInfo(nomCoucheLegende, coucheInfoFormat, coucheDataType, Template),
-                error: this.gestionRetourErreur
-            }));
+            //Appliquer infoUrl au lieu de celui du WMS GetFeatureInfo
+            if (oCoucheObtnInfo.infoUrl !== undefined) {
 
+                var prmt = [];
+                var lonlat = this.carte._carteOL.getLonLatFromPixel(this.px);
+                var point = new Point(lonlat.lon, lonlat.lat).projeter('EPSG:3798');
+
+                prmt.push({
+                    'name': oCoucheObtnInfo.nom,
+                    'projection': 'EPSG:3798',
+                    'x': Math.floor(point.x),
+                    'y': Math.floor(point.y)
+                });
+
+                //Formatter l'url
+                var infoUrlFormat = this.formatUrl(oCoucheObtnInfo.infoUrl, [prmt[0].name, prmt[0].projection, prmt[0].x, prmt[0].y]);
+
+                jqXHRs.push($.ajax({
+                    url: Aide.utiliserProxy(decodeURIComponent(infoUrlFormat)),
+                    context: this,
+                    dataType: coucheDataType,
+                    success: this.traiterRetourInfo(nomCoucheLegende, coucheInfoFormat, coucheDataType, Template),
+                    error: this.gestionRetourErreur(nomCoucheLegende)
+                }));
+
+            } else {
+                //Appliquer Url WMS GetFeatureInfo
+                jqXHRs.push($.ajax({
+                    url: Aide.utiliserProxy(decodeURIComponent(oCoucheObtnInfo.url)),
+                    data: {
+                        LAYERS: oCoucheObtnInfo.nom,
+                        SERVICE: 'WMS',
+                        REQUEST: "GetFeatureInfo",
+                        EXCEPTIONS: "application/vnd.ogc.se_xml",
+                        VERSION: oCoucheObtnInfo.version,
+                        SRS: this.carte._carteOL.getProjection(),
+                        BBOX: this.carte._carteOL.getExtent().toBBOX(),
+                        QUERY_LAYERS: oCoucheObtnInfo.nom,
+                        X: Math.floor(this.px.x),
+                        Y: Math.floor(this.px.y),
+                        INFO_FORMAT: coucheInfoFormat,
+                        FEATURE_COUNT: 100,
+                        WIDTH: this.carte._carteOL.size.w,
+                        HEIGHT: this.carte._carteOL.size.h,
+                        _encodage: encodage,
+                        xsl_template: xslTemplate
+                    },
+                    context: this,
+                    dataType: coucheDataType,
+                    beforeSend: function (jqXHR) {
+                        if (oCoucheObtnInfo.infoEncodage !== undefined) {
+                            if (jqXHR.overrideMimeType) {
+                                jqXHR.overrideMimeType(coucheInfoFormat + "; charset=" + oCoucheObtnInfo.infoEncodage);
+                            }
+                        }
+                    },
+                    success: this.traiterRetourInfo(nomCoucheLegende, coucheInfoFormat, coucheDataType, Declencheur, Template),
+                    error: this.gestionRetourErreur(nomCoucheLegende)
+                }));
+            }
         }
 
 
@@ -269,24 +340,27 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             $.when.apply(null, jqXHRs).done(function () {
                 that.afficherResultats();
                 Aide.cacherMessageChargement();
+            }).fail(function (jqXHRs, textStatus, errorThrown) {
+                Aide.afficherMessageConsole('Erreur Critique: ' + textStatus + " : " + jqXHRs.url + " : " + errorThrown);
+                Aide.cacherMessageChargement();
             });
         });
     };
-    
- 
 
-    OutilInfo.prototype.traiterRetourInfo = function (nomCoucheLegende, coucheInfoFormat, coucheDataType, nomGabarit) {
+
+
+    OutilInfo.prototype.traiterRetourInfo = function (nomCoucheLegende, coucheInfoFormat, coucheDataType, coucheDeclencheur, nomGabarit) {
 
         // On traduit le format de sortie en GeoJson peu import l'appel xml,gml ou gml311
         var oGeoJSON = new OpenLayers.Format.GeoJSON();
 
         return function gestionRetour(data, textStatus, jqXHR) {
-        
+
             // nomCouche et son retour ajax html
             if (coucheInfoFormat === "text/html") {
                 //Si html est vide ne pas ajouter onglet
                 if (this.gestionRetourHtml(data)) {
-                    this.features = this.features.concat([nomCoucheLegende, data]);
+                    this.features = this.features.concat([nomCoucheLegende, data, coucheDataType]);
                 }
             }
 
@@ -301,7 +375,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures)]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
                     }
                 }
             }
@@ -316,13 +390,13 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures)]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
                     }
                 }
             }
 
             // nomCouche et son retour ajax text et applique Hbars si defini
-            if (coucheInfoFormat === "application/vnd.ogc.gml/3.1.1" ) {
+            if (coucheInfoFormat === "application/vnd.ogc.gml/3.1.1") {
 
                 var oFeatures = this.lireGetInfoGml3(data);
 
@@ -332,7 +406,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures)]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
                     }
                 }
 
@@ -360,7 +434,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             var oFormat = new OpenLayers.Format.WMSGetFeatureInfo();
             var oFeatures = oFormat.read_msGMLOutput(gml);
         }
-        return oFeatures
+        return oFeatures;
 
     };
 
@@ -432,9 +506,9 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
     };
 
     OutilInfo.prototype.gestionRetourErreur = function (nomCoucheLegende) {
-   
+
         Aide.cacherMessageChargement();
-   
+
         return function gestionRetour(data, textStatus, jqXhr) {
             this.erreurs++;
             var responseBody = data.responseText;
@@ -442,7 +516,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             if (data.status === 200) {
                 status = "XML invalide";
                 responseBody = "La donnée originale n'est pas valide pour cet outil.";
-                console.error(textStatus + ": " + jqXhr.message);
+                Aide.afficherMessageConsole(textStatus + ": " + jqXhr.message);
             }
             //alert("ERROR: " + textStatus + " : " + textStatus + " : " + contentType + " : " + responseBody);
             Aide.afficherMessage(status, responseBody, "OK", "ERROR");
@@ -452,6 +526,8 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
     OutilInfo.prototype.afficherResultats = function () {
 
         var that = this;
+        var tabExist = false;
+
         if (this.features.length === 0 && this.featuresHbars.length === 0) {
             Aide.cacherMessageChargement();
             // TODO : this is HARDCODED
@@ -500,148 +576,174 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             items: [tabs]
         });
 
-        //Iteration par 2 array contiens nomCouche et son retour ajax
-        for (var i = 0; i < this.features.length; i += 2)
+        //Iteration par 3 : array contient nomCouche, le retour ajax en json et un declencheur s il y en as
+        for (var i = 0; i < this.features.length; i += 3)
         {
             var nonCouche = this.features[i];
             var oFeature = this.features[i + 1];
+            var monDeclencheur = this.features[i + 2];
 
-            if (String(oFeature).length > 0) {
+            if (String(oFeature).length > 0 && monDeclencheur === undefined && monDeclencheur !== "html") {
 
                 try {
+
                     oFeature = $.parseJSON(oFeature);
+
+                    //Gestion du retour type Gml et Xml            
+                    if ($.isArray(oFeature.features)) {
+
+                        var oFeaturesXml = oFeature.features;
+
+                        var aoStores = {}, aoColumns = {}, nStores = 0, aNbItem = [];
+                        for (var j = 0; j < oFeaturesXml.length; j++)
+                        {
+                            var oFeatureXml = oFeaturesXml[j];
+                            var szType = oFeatureXml.type;
+                            var aColumns = [];
+
+                            if (!aoStores[szType])
+                            {
+
+                                aoStores[szType] = new Ext.data.GroupingStore(
+                                        {
+                                            fields: [/*'Couche',*/ 'Item', 'Attribut', 'Valeur'],
+                                            sortInfo: {field: 'Item', direction: 'DESC'},
+                                            groupOnSort: true,
+                                            remoteGroup: false,
+                                            groupField: 'Item'
+                                        }
+                                );
+
+                                aNbItem[szType] = 0;
+                                aColumns.push({header: 'Item', sortable: true, dataIndex: 'Item', width: 50});
+                                aColumns.push({header: 'Attribut', sortable: false, dataIndex: 'Attribut', width: 150});
+                                aColumns.push(
+                                        {id: 'Valeur', header: 'Valeur', sortable: false, dataIndex: 'Valeur',
+                                            renderer: function (value, metaData, record, rowIndex, colIndex, store) {
+                                                metaData.css = 'multilineColumn';
+                                                return value;
+                                            }
+                                        });
+
+                                aoColumns[szType] = aColumns;
+                                nStores++;
+                            }
+                        }
+
+
+                        var RecordTemplate = Ext.data.Record.create([/*{name:'Couche'}, */{name: 'Item'}, {name: 'Attribut'}, {name: 'Valeur'}]);
+                        for (var k = 0; k < oFeaturesXml.length; k++)
+                        {
+                            var oFeatureXml = oFeaturesXml[k];
+                            var szType = oFeatureXml.type;
+                            aNbItem[szType]++;//numéro unique Couche-feature
+
+                            for (var szAttribute in oFeatureXml.properties)
+                            {
+                                var newRecord = new RecordTemplate({/*Couche: szType, */Item: aNbItem[szType], Attribut: szAttribute, Valeur: oFeatureXml.properties[szAttribute]});
+                                aoStores[szType].add(newRecord);
+                            }
+                        }
+
+                        var nGridHeight;
+                        if (nStores > 2) {
+                            nGridHeight = 200;
+                        } else {
+                            nGridHeight = 570 / nStores;
+                        }
+
+
+                        var aoGrids = {};
+                        for (var szType in aoStores)
+                        {
+                            var gridTitle = '';
+                            if (aNbItem[szType] == 1)
+                                gridTitle = nonCouche + ' (' + aNbItem[szType] + ' item)';
+                            else
+                                gridTitle = nonCouche + ' (' + aNbItem[szType] + ' items)';
+
+                            aoGrids[szType] = new Ext.grid.GridPanel({
+                                store: aoStores[szType],
+                                columns: aoColumns[szType],
+                                title: gridTitle,
+                                stripeRows: true,
+                                autoExpandColumn: 'Valeur',
+                                height: 500,
+                                disableSelection: true,
+                                trackMouseOver: false,
+                                enableHdMenu: false,
+                                view: new Ext.grid.GroupingView(
+                                        {
+                                            scrollOffset: 30,
+                                            hideGroupedColumn: true,
+                                            startCollapsed: false,
+                                            getRowClass: function (record, index, rowParams)
+                                            {
+                                                if (record.get('Item') % 2.0 == 0.0)
+                                                    return 'background-bleupale-row';
+                                                else
+                                                    return 'background-white-row';
+                                            }
+                                        })
+                            });
+                        }
+                        //Ajout du retour getFeatureInfo  Gml,Xml
+                        for (var szType in aoStores)
+                        {
+                            tabs.add(aoGrids[szType]);
+                        }
+                    }
                 }
                 catch (e) {
+                    Aide.afficherMessageConsole('Erreur: GetFeatureInfo: <br> Solution possible ajouté le paramètre infoEncodage pour la couche \'' + nonCouche + '<br>' + oFeature + '\' a échoué. <br>' + e);
                 }
+                
+            } else {
 
-                //Gestion du retour type Gml et Xml            
-                if ($.isArray(oFeature.features)) {
-
-                    var oFeaturesXml = oFeature.features;
-
-                    var aoStores = {}, aoColumns = {}, nStores = 0, aNbItem = [];
-                    for (var j = 0; j < oFeaturesXml.length; j++)
-                    {
-                        var oFeatureXml = oFeaturesXml[j];
-                        var szType = oFeatureXml.type;
-                        var aColumns = [];
-
-                        if (!aoStores[szType])
-                        {
-
-                            aoStores[szType] = new Ext.data.GroupingStore(
-                                    {
-                                        fields: [/*'Couche',*/ 'Item', 'Attribut', 'Valeur'],
-                                        sortInfo: {field: 'Item', direction: 'DESC'},
-                                        groupOnSort: true,
-                                        remoteGroup: false,
-                                        groupField: 'Item'
-                                    }
-                            );
-
-                            aNbItem[szType] = 0;
-                            aColumns.push({header: 'Item', sortable: true, dataIndex: 'Item', width: 50});
-                            aColumns.push({header: 'Attribut', sortable: false, dataIndex: 'Attribut', width: 150});
-                            aColumns.push(
-                                    {id: 'Valeur', header: 'Valeur', sortable: false, dataIndex: 'Valeur',
-                                        renderer: function (value, metaData, record, rowIndex, colIndex, store) {
-                                            metaData.css = 'multilineColumn';
-                                            return value;
-                                        }
-                                    });
-
-                            aoColumns[szType] = aColumns;
-                            nStores++;
-                        }
-                    }
-
-
-                    var RecordTemplate = Ext.data.Record.create([/*{name:'Couche'}, */{name: 'Item'}, {name: 'Attribut'}, {name: 'Valeur'}]);
-                    for (var k = 0; k < oFeaturesXml.length; k++)
-                    {
-                        var oFeatureXml = oFeaturesXml[k];
-                        var szType = oFeatureXml.type;
-                        aNbItem[szType]++;//numéro unique Couche-feature
-
-                        for (var szAttribute in oFeatureXml.properties)
-                        {
-                            var newRecord = new RecordTemplate({/*Couche: szType, */Item: aNbItem[szType], Attribut: szAttribute, Valeur: oFeatureXml.properties[szAttribute]});
-                            aoStores[szType].add(newRecord);
-                        }
-                    }
-
-                    var nGridHeight;
-                    if (nStores > 2) {
-                        nGridHeight = 200;
-                    } else {
-                        nGridHeight = 570 / nStores;
-                    }
-
-
-                    var aoGrids = {};
-                    for (var szType in aoStores)
-                    {
-                        var gridTitle = '';
-                        if (aNbItem[szType] == 1)
-                            gridTitle = nonCouche + ' (' + aNbItem[szType] + ' item)';
-                        else
-                            gridTitle = nonCouche + ' (' + aNbItem[szType] + ' items)';
-
-                        aoGrids[szType] = new Ext.grid.GridPanel({
-                            store: aoStores[szType],
-                            columns: aoColumns[szType],
-                            title: gridTitle,
-                            stripeRows: true,
-                            autoExpandColumn: 'Valeur',
-                            height: 500,
-                            disableSelection: true,
-                            trackMouseOver: false,
-                            enableHdMenu: false,
-                            view: new Ext.grid.GroupingView(
-                                    {
-                                        scrollOffset: 30,
-                                        hideGroupedColumn: true,
-                                        startCollapsed: false,
-                                        getRowClass: function (record, index, rowParams)
-                                        {
-                                            if (record.get('Item') % 2.0 == 0.0)
-                                                return 'background-bleupale-row';
-                                            else
-                                                return 'background-white-row';
-                                        }
-                                    })
-                        });
-                    }
-                    //Ajout du retour getFeatureInfo  Gml,Xml
-                    for (var szType in aoStores)
-                    {
-                        tabs.add(aoGrids[szType]);
-                    }
-                } else {
+                if (monDeclencheur === 'html')
+                {
                     //Ajout du retour getFeatureInfo html
-                   // font:16px tahoma,arial,helvetica,sans-serif;
+                    tabExist = true;
                     tabs.add({title: nonCouche,
                         html: oFeature
                     });
                 }
+
+                if (monDeclencheur !== undefined && monDeclencheur !== 'html') {
+
+                    try {
+                        //Le declencheur recoit toujours un json en parapètre
+                        monDeclencheur(oFeature);
+                    }
+                    catch (e) {
+                        Aide.afficherMessageConsole('Erreur: GetFeatureInfo: <br>Le Declencheur pour \'' + nonCouche + '<br>' + oFeature + '\' a échoué. <br>' + e);
+                    }
+
+                }
+
             }
         }
 
 
         if (tabs.items.length > 0) {
+            tabExist = true;
             oResultWindow.add(tabs);
-        };
+        }
 
         //Si nous avons des gabarit Handlebars on appel la fonction
         if (this.featuresHbars.length > 0) {
 
             var hbarTabs = this.afficherResultatsGabaritHbars(tabs);
-
+            tabExist = true;
             oResultWindow.add(hbarTabs);
             hbarTabs.setActiveTab(0);
-        };
+        }
 
-        oResultWindow.show();
+        //Afficher le résultat seulemnt si nous avons des résultats
+        if (tabExist) {
+            oResultWindow.show();
+        }
+
         //Fin du clique on reinitialise
         that.reinitialiser();
 
@@ -655,17 +757,16 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
         for (var i = 0; i < that.featuresHbars.length; i += 3)
         {
             var nonCouche = that.featuresHbars[i];
-            
             var oFeature = $.parseJSON(that.featuresHbars[i + 1]);
             var nomGabarit = that.featuresHbars[i + 2];
             var result = nomGabarit(oFeature);
-      
+
             content.add({title: nonCouche,
                 html: result
             });
 
         }
-          
+
         return content;
 
     };
@@ -682,15 +783,15 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
             ev.stopPropagation();
             ev.preventDefault();
             $(that).next().toggle('fast', function () {
-                if ($(that).parent().hasClass('x-grid-group-collapsed')){
+                if ($(that).parent().hasClass('x-grid-group-collapsed')) {
                     $(that).parent().removeClass('x-grid-group-collapsed');
-                }else{
+                } else {
                     $(that).parent().addClass('x-grid-group-collapsed');
-                }    
+                }
             });
         });
     };
-       /** 
+    /** 
      * Desactiver le toggle l'item du GetInfo
      * @method 
      * @name OutilInfo#desactiverToggleItem
@@ -698,7 +799,7 @@ define(['outil', 'aide', 'browserDetect'], function (Outil, Aide, BrowserDetect)
     OutilInfo.prototype.desactiverToggleItem = function () {
         $(document).off('click', '.toggleItem');
     };
-    
+
     /** 
      * Cacher le GetInfo
      * @method 

--- a/interfaces/navigateur/public/js/app/outil/outilInfo.js
+++ b/interfaces/navigateur/public/js/app/outil/outilInfo.js
@@ -277,11 +277,11 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
                 var prmt = [];
                 var lonlat = this.carte._carteOL.getLonLatFromPixel(this.px);
-                var point = new Point(lonlat.lon, lonlat.lat).projeter('EPSG:3798');
+                var point = new Point(lonlat.lon, lonlat.lat);
 
                 prmt.push({
                     'name': oCoucheObtnInfo.nom,
-                    'projection': 'EPSG:3798',
+                    'projection': this.carte._carteOL.getProjection(),
                     'x': Math.floor(point.x),
                     'y': Math.floor(point.y)
                 });

--- a/interfaces/navigateur/public/js/app/outil/outilInfo.js
+++ b/interfaces/navigateur/public/js/app/outil/outilInfo.js
@@ -264,7 +264,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
             //Exceptionellement IE on doit passer par le proxy pour encodage
             if (BrowserDetect.browser === "Explorer") {
-                encodage = (oCoucheObtnInfo.infoEncodage === undefined) ? 'UTF-8' : encodage;
+                encodage = (oCoucheObtnInfo.infoEncodage === undefined) ? 'UTF-8' : oCoucheObtnInfo.infoEncodage;
             }
 
             //Appliquer un xsl ESRI


### PR DESCRIPTION
1.  Modification de l’outilInfo pour permettre l’application d’un déclencheur. Ce déclencheur donne accès à un script via un url ou un dossier spécifique. Ce script (déclencheur) reçoit en paramètre le json du getFeatureInfo sur la couche. Affichage dans la fenêtre résultats pour  lui-même de l’outilInfo est omis.
   Ex : infoDeclencheur="/specifique/js/declencheur/declencheurCommunesMTQ" 
2.   L’attribut xml infoUrl="url"  permet de spécifier un url qui sera remplacer par l'url GetFeaturInfo de l' OutilInfo Affichage dans la fenêtre résultats habituel.
   Les paramètres possibles sont : nom de la couche wms = {0},  la projection de la carte = {1}, x = {2}, y = {3}.Le caractère "$" sera remplacé par "&" avant l’appel de l’url.

Ex : infoUrl="http://ws.sigexpress.prod.mtq.min.intra/Geocodage.ashx?x={2}$y={3}$rayon=100"  
1.   Amélioration des fonctions infoGabarit , infoEncodage et infoFormat.
2.   Une meilleure gestion des erreurs et l’utilisation   « Aide.afficherMessageConsole » si en erreur et l’ajout de commentaire explicatif dans le code.
3.   Mise à jour du DocumentationXML.markdown 
