### PR TITLE
Correction multiple et gabarit par defaut

### DIFF
--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1497,20 +1497,11 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
 |infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
 |infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
-|infoDeclencheur | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le déclencheur| Non| URL|		|
+|infoAction | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL|		|
 
-*Exemples*
+*Exemples mode infoFormat*
 ```xml
-<couche url="http://ows.geobase.ca/wms/geobase\_en?" nom="nrwn:track"
-protocole="WMS"
-couche titre="Structures MTQ"
-url="http://www.dds.mtq.gouv.qc.ca/dds.aspx" nom="strct\_mtq"
-protocole="WMS" extraParams="NUM\_DOSSR=18475"
-couche id="idCoucheWMS" titre="RFN Voies ferrées"
-url="http://ows.geobase.ca/wms/geobase\_en?" nom="nrwn:track"
-protocole="WMS" fond="false" echelleMin="6000000" echelleMax="1"
-groupe="Test" visible="true" active="faux" opacite="100"
-ordreAffichage="1"/>
+   <couche protocole="WMS" mode="getCapabilities" url="http://geoegl.msp.gouv.qc.ca/cgi-wms/bdga.fcgi?" infoFormat="gml" />
 ```
 
 
@@ -1630,7 +1621,7 @@ Configuration minimale XML
 Configuration minimale BD
 -------------------------
 
-(avec contexte chargé à partir de la BD)
+(avec contexte chargé à partir de la BD)
 
 ```xml
 <navigateur authentification="false" titre="G.O.LOC - Données ouvertes - Gouvernement du Québec">
@@ -1827,7 +1818,7 @@ Contient des ajouts de composantes personnalisées.
 ![](media/igo_avec_edition.png)
 
 
-Configuration maximale
+Configuration maximale
 ----------------------
 
 ```xml

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1495,14 +1495,30 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |mode|Intégrer l'ensemble des couches d'un service WMS|Non  |*getCapabilities*||
 |infoFormat | Indique le format voulu pour l' *OutilInfo* qui sera affiché dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
-|infoGabarit | Indique l'emplacement du script HandleBars qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|		|
+|infoGabarit | Indique l'emplacement du script [HandleBars](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) avec l'extension *.html* qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|
 |infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
-|infoAction | Indique l'emplacement du script qui recevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL|		|
+|infoAction | Indique l'emplacement du script qui reçevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL|		|
 
-*Exemples mode infoFormat*
+*Exemples*
 ```xml
-   <couche protocole="WMS" mode="getCapabilities" url="http://geoegl.msp.gouv.qc.ca/cgi-wms/bdga.fcgi?" infoFormat="gml" />
+   <couche protocole="WMS" mode="getCapabilities"
+   url="http://geoegl.msp.gouv.qc.ca/cgi-wms/bdga.fcgi?" infoFormat="gml" />
 ```
+
+*Exemples*
+```xml
+  <couche titre="Région Administrative" protocole="WMS" 
+   url="http://sigeom.mrn.gouv.qc.ca/SIGEOM_WMS/Request.aspx?" nom="Region_Administrative" active="vrai" infoFormat="html"  />
+```
+
+*Exemples*
+```xml
+    <couche titre="Stations hydrométriques - Seuil de conséquence (public)" protocole="WMS" 
+    url="http://geoegl.msp.gouv.qc.ca/cgi-wms/adnInternetV2.fcgi?" nom="adn_station_max_public_v" 
+    echelleMin="4000000" />
+```
+
+
 
 
 Actions

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1495,7 +1495,7 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |mode|Intégrer l'ensemble des couches d'un service WMS|Non  |*getCapabilities*||
 |infoFormat | Indique le format voulu pour l' *OutilInfo* qui sera affiché dans la fenêtre de résultats après le clique sur la couche dans la carte | Non| *gml*,*gml311*,*xml*,*html*| *gml*|
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
-|infoGabarit | Indique l'emplacement du script [HandleBars](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) avec l'extension *.html* qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte | Non|  URL|
+|infoGabarit | Indique l'emplacement du script [Handlebars](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) avec l'extension *.html* qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte ([exemple](https://github.com/bosthy/igo/blob/dev/interfaces/navigateur/public/template/handlebars.exemple.html),[ exemple simple](https://github.com/bosthy/igo/blob/dev/interfaces/navigateur/public/template/handlebars.exempleSimple.html)) | Non|  URL|
 |infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
 |infoAction | Indique l'emplacement du script qui reçevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL|		|
 

--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1505,20 +1505,23 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
    url="http://geoegl.msp.gouv.qc.ca/cgi-wms/bdga.fcgi?" infoFormat="gml" />
 ```
 
-*Exemples*
 ```xml
   <couche titre="Région Administrative" protocole="WMS" 
-   url="http://sigeom.mrn.gouv.qc.ca/SIGEOM_WMS/Request.aspx?" nom="Region_Administrative" active="vrai" infoFormat="html"  />
+   url="http://sigeom.mrn.gouv.qc.ca/SIGEOM_WMS/Request.aspx?" nom="Region_Administrative" 
+   active="vrai" infoFormat="html"  />
 ```
 
-*Exemples*
 ```xml
     <couche titre="Stations hydrométriques - Seuil de conséquence (public)" protocole="WMS" 
     url="http://geoegl.msp.gouv.qc.ca/cgi-wms/adnInternetV2.fcgi?" nom="adn_station_max_public_v" 
     echelleMin="4000000" />
 ```
 
-
+```xml
+  <couche titre="Structures MTQ" url="http://www.dds.mtq.gouv.qc.ca/dds.aspx" 
+   nom="strct" protocole="WMS"  fond="false" echelleMin="6000000" echelleMax="1" 
+   visible="true" active="faux" opacite="100" ordreAffichage="1"/>
+```
 
 
 Actions

--- a/interfaces/navigateur/public/js/app/outil/outilInfo.js
+++ b/interfaces/navigateur/public/js/app/outil/outilInfo.js
@@ -127,7 +127,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
                     'id': couche.id,
                     'infoFormat': couche.options.infoFormat,
                     'infoEncodage': couche.options.infoEncodage,
-                    'infoDeclencheur': couche.options.infoDeclencheur,
+                    'infoAction': couche.options.infoAction,
                     'infoUrl': couche.options.infoUrl,
                     'infoGabarit': couche.options.infoGabarit,
                     'estInterrogable': couche.options.estInterrogable,
@@ -165,11 +165,18 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
     OutilInfo.prototype.obtCouchesHbars = function (couches) {
         var that = this;
+        
 
         //On va chercher tous les templates nécessaires pour faire un seul require
         var doitRequire = [];
         for (var d = 0; d < couches.length; ++d) {
             var couche = couches[d];
+          
+            //On apllique systématiquement hbars 
+            if (couche.infoGabarit === undefined) {
+                couche.infoGabarit = "template/defaut"
+            }
+            
             if (couche.infoGabarit !== undefined && couche.infoGabarit.substring(couche.infoGabarit.lastIndexOf(".")) !== ".xsl") {
                 doitRequire.push('hbars!' + couche.infoGabarit);
             }
@@ -199,8 +206,8 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
         var doitRequire = [];
         for (var d = 0; d < couches.length; ++d) {
             var couche = couches[d];
-            if (couche.infoDeclencheur !== undefined) {
-                doitRequire.push(couche.infoDeclencheur + '.js');
+            if (couche.infoAction !== undefined) {
+                doitRequire.push(couche.infoAction + '.js');
             }
         }
 
@@ -210,8 +217,8 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
             for (var c = 0; c < couches.length; ++c) {
                 var couche = couches[c];
                 //On obtient toutes les couches avec un gabarit 
-                if (couche.infoDeclencheur !== undefined) {
-                    couche._declencheur = arguments[i];
+                if (couche.infoAction !== undefined) {
+                    couche._action = arguments[i];
                     i++;
                 };
             }
@@ -230,7 +237,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
             var oCoucheObtnInfo = couchesInterroger[j];
             var nomCoucheLegende = oCoucheObtnInfo.titre;
             var Template = oCoucheObtnInfo._template;
-            var Declencheur = oCoucheObtnInfo._declencheur;
+            var Declencheur = oCoucheObtnInfo._action;
 
             var coucheInfoFormat;
 
@@ -349,7 +356,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
 
 
-    OutilInfo.prototype.traiterRetourInfo = function (nomCoucheLegende, coucheInfoFormat, coucheDataType, coucheDeclencheur, nomGabarit) {
+    OutilInfo.prototype.traiterRetourInfo = function (nomCoucheLegende, coucheInfoFormat, coucheDataType, coucheAction, nomGabarit) {
 
         // On traduit le format de sortie en GeoJson peu import l'appel xml,gml ou gml311
         var oGeoJSON = new OpenLayers.Format.GeoJSON();
@@ -369,13 +376,13 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
                 var oFormat = new OpenLayers.Format.WMSGetFeatureInfo();
                 var oFeatures = oFormat.read_FeatureInfoResponse(data);
 
-                if (nomGabarit !== undefined) {
+                if (coucheAction === undefined) {
                     if (this.gestionRetourXml(oFeatures)) {
                         this.featuresHbars = this.featuresHbars.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), nomGabarit]);
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheAction]);
                     }
                 }
             }
@@ -384,13 +391,13 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
                 var oFeatures = this.lireGetInfoGml(data);
 
-                if (nomGabarit !== undefined) {
+                if (coucheAction === undefined) {
                     if (this.gestionRetourXml(oFeatures)) {
                         this.featuresHbars = this.featuresHbars.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), nomGabarit]);
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheAction]);
                     }
                 }
             }
@@ -400,13 +407,13 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
 
                 var oFeatures = this.lireGetInfoGml3(data);
 
-                if (nomGabarit !== undefined) {
+                if (coucheAction === undefined) {
                     if (this.gestionRetourXml(oFeatures)) {
                         this.featuresHbars = this.featuresHbars.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), nomGabarit]);
                     }
                 } else {
                     if (this.gestionRetourXml(oFeatures)) {
-                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheDeclencheur]);
+                        this.features = this.features.concat([nomCoucheLegende, oGeoJSON.write(oFeatures), coucheAction]);
                     }
                 }
 
@@ -581,118 +588,12 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
         {
             var nonCouche = this.features[i];
             var oFeature = this.features[i + 1];
-            var monDeclencheur = this.features[i + 2];
+            var monAction = this.features[i + 2];
 
-            if (String(oFeature).length > 0 && monDeclencheur === undefined && monDeclencheur !== "html") {
+            if (String(oFeature).length > 0 && monAction === undefined && monAction !== "html") {
 
-                try {
-
-                    oFeature = $.parseJSON(oFeature);
-
-                    //Gestion du retour type Gml et Xml            
-                    if ($.isArray(oFeature.features)) {
-
-                        var oFeaturesXml = oFeature.features;
-
-                        var aoStores = {}, aoColumns = {}, nStores = 0, aNbItem = [];
-                        for (var j = 0; j < oFeaturesXml.length; j++)
-                        {
-                            var oFeatureXml = oFeaturesXml[j];
-                            var szType = oFeatureXml.type;
-                            var aColumns = [];
-
-                            if (!aoStores[szType])
-                            {
-
-                                aoStores[szType] = new Ext.data.GroupingStore(
-                                        {
-                                            fields: [/*'Couche',*/ 'Item', 'Attribut', 'Valeur'],
-                                            sortInfo: {field: 'Item', direction: 'DESC'},
-                                            groupOnSort: true,
-                                            remoteGroup: false,
-                                            groupField: 'Item'
-                                        }
-                                );
-
-                                aNbItem[szType] = 0;
-                                aColumns.push({header: 'Item', sortable: true, dataIndex: 'Item', width: 50});
-                                aColumns.push({header: 'Attribut', sortable: false, dataIndex: 'Attribut', width: 150});
-                                aColumns.push(
-                                        {id: 'Valeur', header: 'Valeur', sortable: false, dataIndex: 'Valeur',
-                                            renderer: function (value, metaData, record, rowIndex, colIndex, store) {
-                                                metaData.css = 'multilineColumn';
-                                                return value;
-                                            }
-                                        });
-
-                                aoColumns[szType] = aColumns;
-                                nStores++;
-                            }
-                        }
-
-
-                        var RecordTemplate = Ext.data.Record.create([/*{name:'Couche'}, */{name: 'Item'}, {name: 'Attribut'}, {name: 'Valeur'}]);
-                        for (var k = 0; k < oFeaturesXml.length; k++)
-                        {
-                            var oFeatureXml = oFeaturesXml[k];
-                            var szType = oFeatureXml.type;
-                            aNbItem[szType]++;//numéro unique Couche-feature
-
-                            for (var szAttribute in oFeatureXml.properties)
-                            {
-                                var newRecord = new RecordTemplate({/*Couche: szType, */Item: aNbItem[szType], Attribut: szAttribute, Valeur: oFeatureXml.properties[szAttribute]});
-                                aoStores[szType].add(newRecord);
-                            }
-                        }
-
-                        var nGridHeight;
-                        if (nStores > 2) {
-                            nGridHeight = 200;
-                        } else {
-                            nGridHeight = 570 / nStores;
-                        }
-
-
-                        var aoGrids = {};
-                        for (var szType in aoStores)
-                        {
-                            var gridTitle = '';
-                            if (aNbItem[szType] == 1)
-                                gridTitle = nonCouche + ' (' + aNbItem[szType] + ' item)';
-                            else
-                                gridTitle = nonCouche + ' (' + aNbItem[szType] + ' items)';
-
-                            aoGrids[szType] = new Ext.grid.GridPanel({
-                                store: aoStores[szType],
-                                columns: aoColumns[szType],
-                                title: gridTitle,
-                                stripeRows: true,
-                                autoExpandColumn: 'Valeur',
-                                height: 500,
-                                disableSelection: true,
-                                trackMouseOver: false,
-                                enableHdMenu: false,
-                                view: new Ext.grid.GroupingView(
-                                        {
-                                            scrollOffset: 30,
-                                            hideGroupedColumn: true,
-                                            startCollapsed: false,
-                                            getRowClass: function (record, index, rowParams)
-                                            {
-                                                if (record.get('Item') % 2.0 == 0.0)
-                                                    return 'background-bleupale-row';
-                                                else
-                                                    return 'background-white-row';
-                                            }
-                                        })
-                            });
-                        }
-                        //Ajout du retour getFeatureInfo  Gml,Xml
-                        for (var szType in aoStores)
-                        {
-                            tabs.add(aoGrids[szType]);
-                        }
-                    }
+                try {  
+                   oFeature = $.parseJSON(oFeature);
                 }
                 catch (e) {
                     Aide.afficherMessageConsole('Erreur: GetFeatureInfo: <br> Solution possible ajouté le paramètre infoEncodage pour la couche \'' + nonCouche + '<br>' + oFeature + '\' a échoué. <br>' + e);
@@ -700,7 +601,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
                 
             } else {
 
-                if (monDeclencheur === 'html')
+                if (monAction === 'html')
                 {
                     //Ajout du retour getFeatureInfo html
                     tabExist = true;
@@ -709,11 +610,11 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
                     });
                 }
 
-                if (monDeclencheur !== undefined && monDeclencheur !== 'html') {
+                if (monAction !== undefined && monAction !== 'html') {
 
                     try {
                         //Le declencheur recoit toujours un json en parapètre
-                        monDeclencheur(oFeature);
+                        monAction(oFeature);
                     }
                     catch (e) {
                         Aide.afficherMessageConsole('Erreur: GetFeatureInfo: <br>Le Declencheur pour \'' + nonCouche + '<br>' + oFeature + '\' a échoué. <br>' + e);
@@ -760,7 +661,13 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
             var oFeature = $.parseJSON(that.featuresHbars[i + 1]);
             var nomGabarit = that.featuresHbars[i + 2];
             var result = nomGabarit(oFeature);
-
+            
+            //Pour avoir le nombre d'item dans le titre
+            if (oFeature.features !== undefined && oFeature.features.length === 1)
+                                nonCouche = nonCouche + ' (' + oFeature.features.length + ' item)';
+                            else
+                                nonCouche = nonCouche + ' (' + oFeature.features.length + ' items)';
+            
             content.add({title: nonCouche,
                 html: result
             });

--- a/interfaces/navigateur/public/js/app/outil/outilInfo.js
+++ b/interfaces/navigateur/public/js/app/outil/outilInfo.js
@@ -346,7 +346,6 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
             Aide.afficherMessageChargement({message: "Chargement de votre requête, patientez un moment..."});
             $.when.apply(null, jqXHRs).done(function () {
                 that.afficherResultats();
-                Aide.cacherMessageChargement();
             }).fail(function (jqXHRs, textStatus, errorThrown) {
                 Aide.afficherMessageConsole('Erreur: ' + textStatus + " : " + jqXHRs.responseText + " : " + errorThrown);
                 Aide.cacherMessageChargement();
@@ -643,6 +642,7 @@ define(['outil', 'aide', 'browserDetect', 'point'], function (Outil, Aide, Brows
         //Afficher le résultat seulemnt si nous avons des résultats
         if (tabExist) {
             oResultWindow.show();
+            Aide.cacherMessageChargement();
         }
 
         //Fin du clique on reinitialise

--- a/interfaces/navigateur/public/template/defaut.html
+++ b/interfaces/navigateur/public/template/defaut.html
@@ -1,0 +1,91 @@
+
+{{!-- Fichier gabarit pour remplacer tableau Ext-JS pour les cas du gml version IGO 1.0.0 --}}
+
+<div class="x-panel-body x-panel-body-noheader x-panel-body-noborder" id="hbs-gen269"
+     style="overflow: auto; width: 627px; height: 516px;">
+    <div class="x-grid3" hidefocus="true" id="hbs-gen270" style="width: 627px; height: 516px;">
+        <div class="x-grid3-viewport" id="hbs-gen271">
+            <div class="x-grid3-header" id="hbs-gen272">
+                <div class="x-grid3-header-inner" id="hbs-gen274" style="width: 627px;">
+                    <div class="x-grid3-header-offset" style="width: 627px;">
+                        <table border="0" cellspacing="0" cellpadding="0" style="width: 597px;">
+                            <thead>
+                                <tr class="x-grid3-hd-row">
+                                    <td class="x-grid3-hd x-grid3-cell x-grid3-td-0 x-grid3-cell-first sort-desc" style="width: 50px;
+                                        display: none;">
+                                        <div class="x-grid3-hd-inner x-grid3-hd-0" unselectable="on" style="">
+                                            Item<img alt="" class="x-grid3-sort-icon" src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></div>
+                                    </td>
+                                    <td class="x-grid3-hd x-grid3-cell x-grid3-td-1" style="width: 150px;">
+                                        <div class="x-grid3-hd-inner x-grid3-hd-1" unselectable="on" style="">
+                                            Attribut<img alt="" class="x-grid3-sort-icon" src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></div>
+                                    </td>
+                                    <td class="x-grid3-hd x-grid3-cell x-grid3-td-Valeur x-grid3-cell-last" style="width: 447px;">
+                                        <div class="x-grid3-hd-inner x-grid3-hd-Valeur" unselectable="on" style="">
+                                            Valeur<img alt="" class="x-grid3-sort-icon" src="data:image/gif;base64,R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></div>
+                                    </td>
+                                </tr>
+                            </thead>
+                        </table>
+                    </div>
+                </div>
+                <div class="x-clear">
+                </div>
+            </div>
+
+            <div class="x-grid3-scroller" id="hbs-gen310" style="width: 698px; height: 518px;">
+                <div class="x-grid3-body" style="width: 668px;" id="hbs-gen312">
+
+                    {{#each .}}
+                    {{#each .}}
+
+                    <div id="hbs-gen306-gp-Item-{{@index}}" class="x-grid-group" >
+
+                        <div id="hbs-gen306-gp-Item-{{@index}}-hd" class="x-grid-group-hd toggleItem" style="width: 668px;">
+                            <div class="x-grid-group-title">
+                                Item: {{@index}}</div>
+                        </div>
+
+                        <div id="hbs-gen306-gp-Item-{{@index}}-bd" class="x-grid-group-body">
+
+                            {{#each .}}
+                            {{#each .}}
+
+                            <div class="x-grid3-row   background-white-row x-grid3-row-first " style="width: 668px;">
+                                <table class="x-grid3-row-table" border="0" cellspacing="0" cellpadding="0" style="width: 668px;">
+                                    <tbody>
+                                        <tr>
+                                            <td tabindex="0" style="width: 48px; display: none;" class="x-grid3-col x-grid3-cell x-grid3-td-0 x-grid3-cell-first ">
+                                                <div unselectable="on" class="x-grid3-cell-inner x-grid3-col-0">
+                                                    {{@index}}</div>
+                                            </td>
+                                            <td class="x-grid3-col x-grid3-cell x-grid3-td-1 " style="width: 150px;" tabindex="0">
+                                                <div class="x-grid3-cell-inner x-grid3-col-1" unselectable="on"> {{@key}}</div>
+                                            </td>
+                                            <td class="x-grid3-col x-grid3-cell x-grid3-td-Valeur multilineColumn" style="width: 518px;"
+                                                tabindex="0">
+                                                <div class="x-grid3-cell-inner x-grid3-col-Valeur" unselectable="on">{{{this}}}</div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+
+                            {{/each}}
+                            {{/each}}
+
+                        </div>
+                    </div>
+
+                    {{/each}}
+                    {{/each}}
+
+                </div>
+                <div class="x-grid3-resize-marker" id="hbs-gen314">
+                    &nbsp;</div>
+                <div class="x-grid3-resize-proxy" id="hbs-gen315">
+                    &nbsp;</div>
+            </div>  
+        </div>
+    </div>
+</div>

--- a/interfaces/navigateur/public/template/handlebars.exemple.html
+++ b/interfaces/navigateur/public/template/handlebars.exemple.html
@@ -1,0 +1,13 @@
+{{!-- Fichier gabarit hbars qui affiche tout les champs et ces valeurs version IGO 1.0.0 --}}
+<ul>
+  {{#each .}}
+    {{#each .}}
+     {{#each .}}
+       {{#each .}}
+     <li> {{@key}}:{{this}} </li>
+        {{/each}}
+       {{/each}}
+     {{/each}}
+   {{/each}}
+</ul>
+

--- a/interfaces/navigateur/public/template/handlebars.exempleSimple.html
+++ b/interfaces/navigateur/public/template/handlebars.exempleSimple.html
@@ -1,0 +1,24 @@
+{{!-- Fichier gabarit hbars exemple simple version IGO 1.0.0 --}}
+<table class="" style="width: 556px;" border="0" cellSpacing="0" cellPadding="0" >
+   {{!-- Format tableau paysage une occurence par ligne --}}
+   <thead>
+    <tr>
+         {{!-- Alias nom des champs --}}
+        <th>Identifiant </th>
+        <th>Date </th>
+        <th>Vidéo </th>
+    </tr>
+ </thead>
+ <tbody>
+     {{#features}}
+       {{#properties}}
+        <tr>
+              {{!-- nom des champs --}}
+            <td>{{IDE_TRACE}}</td>
+            <td>{{DAT_ORIGN}}</td>
+            <td>{{{URL}}}</td>
+        </tr>
+    {{/properties}} 
+   {{/features}}
+ </tbody>
+</table>


### PR DESCRIPTION
Ajustements de la documentation pour renommer infoDeclencheur par InfoAction.
Ajustemnts du code de l'outilInfo pour InfoAction.
Remplacer le grids, columns et stores de Ext JS par un Gabarit Handlebars par defaut qui sera  dorénavent toujours appliqué sur le résultat du GetInfo gml,xml et gml311.
Le Gabarit par "defaut.html" est placé dans le dossier public/template/
Avec un paramètre infoGabarit ce dernier prendra priorité sur "public/template/defaut".
