### PR TITLE
Separate windows documentation and add missing information about CRLF issue

### DIFF
--- a/doc/installation/windowsInstall.md
+++ b/doc/installation/windowsInstall.md
@@ -1,0 +1,61 @@
+### Installation depuis Windows
+
+Cette documentation a été testée avec Windows 8.1.
+
+Sur Windows, il suffit de télécharger et installer:
+
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi)
+* [Git for Windows](https://msysgit.github.io/)
+
+le plugin vagrant-r10k: 
+
+```sh
+$ vagrant plugin install vagrant-r10k
+``` 
+
+Au niveau de la configuration de Git, assurez-vous d'avoir l'option core.autocrlf = input. Pour ce faire, dans Git Bash, faites la commande suivante (à effectuer la première fois seulement): 
+
+```sh
+$ git config --global core.autocrlf input
+```
+
+#### Démarrage
+
+À la racine de votre dépôt git (où se trouve le fichier Vagrantfile), exécutez la commande suivante en utilisant Git Bash:
+
+```sh
+$ vagrant up
+```
+
+***
+
+### Installation from Windows host
+
+This has been tested on Windows 8.1.
+
+On Windows, you only need to download and install:
+
+* [VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+* [Vagrant](https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi)
+* [Git for Windows](https://msysgit.github.io/)
+
+and vagrant-r10k plugin: 
+
+```sh
+$ vagrant plugin install vagrant-r10k
+``` 
+
+About Git configuration, be sure to have the option core.autocrlf = input. In Git Bash, execute the following command (first time only): 
+
+```sh
+$ git config --global core.autocrlf input
+```
+
+#### Start-up
+
+At the root of your git repository (where is the Vagrantfile), enter following command using Git Bash:
+
+```sh
+$ vagrant up
+```

--- a/doc/installation/windowsInstall.md
+++ b/doc/installation/windowsInstall.md
@@ -1,4 +1,4 @@
-### Installation depuis Windows
+### Installation d'une machine virtuelle avec Vagrant depuis Windows
 
 Cette documentation a été testée avec Windows 8.1.
 
@@ -30,7 +30,7 @@ $ vagrant up
 
 ***
 
-### Installation from Windows host
+### Installation of virtual machine with Vagrant from Windows host
 
 This has been tested on Windows 8.1.
 
@@ -52,7 +52,7 @@ About Git configuration, be sure to have the option core.autocrlf = input. In Gi
 $ git config --global core.autocrlf input
 ```
 
-#### Start-up
+#### Start-Up
 
 At the root of your git repository (where is the Vagrantfile), enter following command **using Git Bash**:
 

--- a/doc/installation/windowsInstall.md
+++ b/doc/installation/windowsInstall.md
@@ -22,7 +22,7 @@ $ git config --global core.autocrlf input
 
 #### Démarrage
 
-À la racine de votre dépôt git (où se trouve le fichier Vagrantfile), exécutez la commande suivante en utilisant Git Bash:
+À la racine de votre dépôt git (où se trouve le fichier Vagrantfile), exécutez la commande suivante **en utilisant Git Bash**:
 
 ```sh
 $ vagrant up
@@ -54,7 +54,7 @@ $ git config --global core.autocrlf input
 
 #### Start-up
 
-At the root of your git repository (where is the Vagrantfile), enter following command using Git Bash:
+At the root of your git repository (where is the Vagrantfile), enter following command **using Git Bash**:
 
 ```sh
 $ vagrant up

--- a/readme.md
+++ b/readme.md
@@ -22,13 +22,14 @@ Guide d'installation rapide pour installer et démarrer une machine virtuelle pr
 
 Cette procédure a été testée avec un système d'exploitation Ubuntu 14.04. Elle permet d'installer Vagrant avec comme provider VirtualBox.
 
+Documentation Windows disponible [ici](doc/installation/windowsInstall.md).
+
 ```sh
 $ sudo apt-get install virtualbox
 $ wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
 $ sudo dpkg -i vagrant_1.7.2_x86_64.deb
 $ vagrant plugin install vagrant-r10k
 ```
-* Sur Windows, il suffit de télécharger et installer VirtualBox (https://www.virtualbox.org/wiki/Downloads) et Vagrant (https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi) et ensuite le plugin vagrant-r10k (en ligne de commande). Le reste de la procédure pour démarrer la machine virtuelle demeure la même (en ligne de commande Windows).
 
 #### Démarrage
 
@@ -56,13 +57,14 @@ Quick installation and start-up guide to install and start a VM to test and/or d
 
 These steps has been tested with Ubuntu 14.04. It allows to install Vagrant with VirtualBox as a provider.
 
+Windows documentation available [here](doc/installation/windowsInstall.md).
+
 ```sh
 $ sudo apt-get install virtualbox
 $ wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2_x86_64.deb
 $ sudo dpkg -i vagrant_1.7.2_x86_64.deb
 $ vagrant plugin install vagrant-r10k
 ```
-* On Windows, you only need to download and install VirtualBox (https://www.virtualbox.org/wiki/Downloads) and Vagrant (https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.2.msi) and finally the vagrant-r10k plugin (with command line). Other steps to start the VM are the same as Linux (but with Windows command line).
 
 #### Start-up
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Since this project is open source, anyone can contribute as long as they share t
 All contributors in the project will keep their property rights on the project.
 
 ***
-### Installation et démarrage de l'environnement de développement
+### Installation et démarrage
 
 Guide d'installation rapide pour installer et démarrer une machine virtuelle préconfigurée pour tester et/ou développer dans IGO.
 
@@ -22,7 +22,11 @@ Guide d'installation rapide pour installer et démarrer une machine virtuelle pr
 
 Cette procédure a été testée avec un système d'exploitation Ubuntu 14.04. Elle permet d'installer Vagrant avec comme provider VirtualBox.
 
-Documentation Windows disponible [ici](doc/installation/windowsInstall.md).
+> **Note pour les utilisateurs de Windows**
+
+> La documentation pour l'installation sous Windows avec Vagrant est disponible [ici](doc/installation/windowsInstall.md).
+
+Entrez les commandes suivantes dans un terminal:
 
 ```sh
 $ sudo apt-get install virtualbox
@@ -49,7 +53,7 @@ Documentation Vagrant: **http://docs.vagrantup.com/v2/cli/index.html**
 
 IGO-Navigateur: **http://localhost:4579/navigateur/**
 ***
-### Development environnement installation and start-up
+### Installation and start-up
 
 Quick installation and start-up guide to install and start a VM to test and/or develop in IGO.
 
@@ -57,7 +61,9 @@ Quick installation and start-up guide to install and start a VM to test and/or d
 
 These steps has been tested with Ubuntu 14.04. It allows to install Vagrant with VirtualBox as a provider.
 
-Windows documentation available [here](doc/installation/windowsInstall.md).
+> **Note for Windows users**
+
+> Windows documentation to install IGO with Vagrant is available [here](doc/installation/windowsInstall.md).
 
 ```sh
 $ sudo apt-get install virtualbox
@@ -66,7 +72,7 @@ $ sudo dpkg -i vagrant_1.7.2_x86_64.deb
 $ vagrant plugin install vagrant-r10k
 ```
 
-#### Start-up
+#### Start-Up
 
 At the root of your git repository (where is the Vagrantfile), enter following command:
 


### PR DESCRIPTION
Windows documentation about vagrant installation is now in a separate file. I added some information about Git for Windows needs when you use a Windows host to install and start a Vagrant machine and the problem with CRLF.
