### PR TITLE
Modif de outilInfo pour fonctions afficherProprietes

### DIFF
--- a/interfaces/navigateur/public/js/app/helper/fonctions.js
+++ b/interfaces/navigateur/public/js/app/helper/fonctions.js
@@ -4,7 +4,7 @@
  * and open the template in the editor.
  */
 
-define(['aide', 'analyseurGeoJSON', 'handlebars'], function(Aide, AnalyseurGeoJSON, Handlebars) {
+define(['aide', 'analyseurGeoJSON','handlebars'], function(Aide, AnalyseurGeoJSON, Handlebars) {
 
     function Fonctions(){
 


### PR DESCRIPTION
Retirer de l'outil info les requireJS et tout le code pris en charge par les fonctions:
afficherProprietes et executerAction.

Fonctions,executerAction rest a tester avec de paramètres de plus et infoUrl aussi.
