### PR TITLE
Modif poxy pour Https avec authentification pour Mapserver et Zoo (SSL)

### DIFF
--- a/interfaces/navigateur/app/controllers/IgoController.php
+++ b/interfaces/navigateur/app/controllers/IgoController.php
@@ -420,7 +420,7 @@ class IgoController extends ControllerBase {
             } else {
                 $trustedDom = '#' . preg_quote($regex, '#') . '#';
             }
-            if(preg_replace($trustedDom, 'ok', $service) === "ok"){
+             if($trustedDom === $service || preg_replace($trustedDom, 'ok', $service) === "ok"){
                 return $regex;
             }
         }


### PR DESCRIPTION
Lorsqu'il il y a un ou plusieurs wfs sécurisés parmi les couches que Zoo (wps) utilisent dans l'analyse spatiale il faut ajouter l'usager et le mot de passe dans le xml(payload) pour chaque url (xlink:href) avant son envoie vers Zoo. L'usager et le mot de passe proviennent de la chaîne encrypter dans le « config.php ». Ceci est un début de développement et des essaies plus poussés viendrons dans les prochaines semaines. Normalement seulement les schémas https avec zoo devraient être affectés.
