### PR TITLE
enlever config inutile

### DIFF
--- a/doc/installation/installation_linux_base.md
+++ b/doc/installation/installation_linux_base.md
@@ -18,11 +18,9 @@ git clone https://github.com/infra-geo-ouverte/igo.git  <br />
 
 ** Changer le groupe de ces dossiers par l'usager de votre serveur Web  <br />
 chgrp www-data /var/www/html/igo/interfaces/navigateur/app/cache  <br />
-chgrp www-data /var/www/html/igo/pilotage/app/cache  
 
 ** Donner le droit d'écriture à ces dossiers  <br />
 chmod 775 /var/www/html/igo/interfaces/navigateur/app/cache  <br />
-chmod 775 /var/www/html/igo/pilotage/app/cache  <br />
 
 ## Cloner les librairies
 cd igo <br /> 


### PR DESCRIPTION
le pilotage est rendu un module et le dossier "/cache"  n'est plus là.
c'est bien ça ?
