### PR TITLE
Fix conflit entre getInfo et afficherInfobulle

### DIFF
--- a/interfaces/navigateur/public/js/app/carte.js
+++ b/interfaces/navigateur/public/js/app/carte.js
@@ -229,7 +229,7 @@ define(['point', 'occurence', 'limites', 'gestionCouches', 'evenement', 'aide', 
                 that.declencher({
                     type: "quitterSurvolCarte"
                 });
-                clearInterval(that._timerEvenementPauseSurvol);
+                clearTimeout(that._timerEvenementPauseSurvol);
             },
             mousemove: function(e) {
                 that.coordSouris = e.xy;
@@ -242,9 +242,9 @@ define(['point', 'occurence', 'limites', 'gestionCouches', 'evenement', 'aide', 
                     x: lonlat.lon,
                     y: lonlat.lat
                 });
-                clearInterval(that._timerEvenementPauseSurvol);
-                that._timerEvenementPauseSurvol = setInterval(function() {
-                    clearInterval(that._timerEvenementPauseSurvol);
+                clearTimeout(that._timerEvenementPauseSurvol);
+                that._timerEvenementPauseSurvol = setTimeout(function() {
+                    clearTimeout(that._timerEvenementPauseSurvol);
                     that.declencher({
                         type: "pauseSurvolCarte",
                         x: that._carteOL.getLonLatFromViewPortPx(that.coordSouris).lon,

--- a/interfaces/navigateur/public/js/app/helper/aide.js
+++ b/interfaces/navigateur/public/js/app/helper/aide.js
@@ -627,6 +627,7 @@ define([], function() {
     */
     Aide.afficherInfobulle = function(contenu, options) {
         options = options || {};
+        clearInterval(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
         var $divInfobulle = $('#divInfobulle');
         // Si l'infobulle n'est pas déjà créée, en faire la création
         if ($divInfobulle.length == 0){
@@ -658,7 +659,7 @@ define([], function() {
             $divInfobulle.css({ 'top': options.y + 'px' });            
         } else {
             // Éviter que l'infobulle s'affiche en dehors de l'écran
-            var y = Math.round(this.obtenirNavigateur().carte.coordSouris.y) + this.obtenirNavigateur().obtenirPanneauxParType('PanneauCarte')[0]._panel.y - $divInfobulle.height();
+            var y = Math.round(this.obtenirNavigateur().carte.coordSouris.y) + this.obtenirNavigateur().obtenirPanneauxParType('PanneauCarte')[0]._panel.y - $divInfobulle.height() - 3;
             if (this.obtenirNavigateur().obtenirBarreOutils()){
                 y += this.obtenirNavigateur().obtenirBarreOutils()._panelContainer.getTopToolbar().getHeight();            
             }
@@ -678,6 +679,7 @@ define([], function() {
     * @name Aide#cacherInfobulle
     */
     Aide.cacherInfobulle = function(){
+         clearInterval(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
         $('#divInfobulle').hide();
     };
    

--- a/interfaces/navigateur/public/js/app/helper/aide.js
+++ b/interfaces/navigateur/public/js/app/helper/aide.js
@@ -627,7 +627,7 @@ define([], function() {
     */
     Aide.afficherInfobulle = function(contenu, options) {
         options = options || {};
-        clearInterval(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
+        clearTimeout(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
         var $divInfobulle = $('#divInfobulle');
         // Si l'infobulle n'est pas déjà créée, en faire la création
         if ($divInfobulle.length == 0){
@@ -679,7 +679,7 @@ define([], function() {
     * @name Aide#cacherInfobulle
     */
     Aide.cacherInfobulle = function(){
-         clearInterval(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
+         clearTimeout(Aide.obtenirNavigateur().carte._timerEvenementPauseSurvol);
         $('#divInfobulle').hide();
     };
    


### PR DESCRIPTION
Déplacement de l'infobulle de trois pixel en y pour permettre a l'outil getInfo de fonctionner sans déplacer la souris.
Et aussi les fonction "afficherInfobulle" et "cacherInfobulle"  l'ajout  du "clearInterval"  est nécessaire sinon les appels vers notre service web sont en continue c.a.d n'arrête jamais sans délacer la souris.
