### PR TITLE
Déplacement de la securité du proxy vers igoController + Ajustement outilInfo

### DIFF
--- a/interfaces/navigateur/api/index.php
+++ b/interfaces/navigateur/api/index.php
@@ -805,8 +805,6 @@ try {
         $igoController = new IgoController();
         $auth = $igoController->obtenirChaineConnexion($service, $restService);  
         
-        $url = $auth['url'];    
-
         $authtmp['auth'] = $auth;
         $options = array_merge($options, $authtmp);
         

--- a/interfaces/navigateur/api/index.php
+++ b/interfaces/navigateur/api/index.php
@@ -461,56 +461,7 @@ try {
     });
 
 
-    /**
-     * Obtenir Chaine de connexion au site securise
-     * @param ??? $service
-     * @param ??? $restService
-     * @return ??? $auth
-     */
-     
-    function obtenirChaineConnexion($service, $restService){  
-        global $app;
-         //Services  
-        $igoController = new IgoController();
-
-        $permisUrl = $igoController->obtenirPermisUrl($service, $restService);
-        
-        if($permisUrl === false){
-            http_response_code(403);
-            die("Vous n'avez pas les droits pour ce service.");
-        } 
-
-       //Decrypter la chaine de connexion
-        if (!empty($permisUrl['connexion']) || !empty($permisUrl['user'])) {
-            $auth = array();
-            if(!empty($permisUrl['user'])) {
-                $auth['user'] = $permisUrl['user']; 
-            }
-            if(!empty($permisUrl['pass'])) {
-                $auth['pass'] = $permisUrl['pass']; 
-            }
-            if(!empty($permisUrl['methode'])) {
-                $auth['method'] = $permisUrl['methode']; 
-            }
-
-            if(!empty($permisUrl['connexion'])){
-                $crypt = $app->getDI()->get("crypt");
-                $chaine = explode(",", $crypt->decryptBase64(urldecode($permisUrl['connexion'])));
-                $auth['user'] = ltrim(trim($chaine[0]), " user:");
-                $auth['pass'] = ltrim(trim($chaine[1]), " pass:");
-                if (empty($auth['pass'])) {
-                    header('Content-Type: text/html; charset=utf-8');
-                    http_response_code(401);
-                    die("Votre clé n'est pas décryptée correctement.");
-                }
-            }
-           
-        }
-       
-          $auth['url'] = $permisUrl['url'];
-          return $auth;            
-    }
-    
+   
 
 
     /**
@@ -851,7 +802,9 @@ try {
             die("Vous devez être connecté pour utiliser ce service");
         }
         
-        $auth = obtenirChaineConnexion ($service, $restService);   
+        $igoController = new IgoController();
+        $auth = $igoController->obtenirChaineConnexion($service, $restService);  
+        
         $url = $auth['url'];    
 
         $authtmp['auth'] = $auth;
@@ -962,7 +915,7 @@ try {
      * @param
      * @return
      */
-    function proxyRequestNavigateur($url, $data, $method, $options) {        
+    function proxyRequestNavigateur($url, $data, $method, $options) {         
         $ch = curl_init();
 
         curl_setopt($ch, CURLOPT_URL, $url);
@@ -1009,80 +962,11 @@ try {
                 'SOAPAction:' . $_SERVER['HTTP_SOAPACTION']));
         }
 
-        if (!empty($options['auth'])) {
-            $auth = $options['auth'];
-            if (isset($auth['method']) && isset($auth['user']) && isset($auth['pass'])) { 	
-            	 //On obtient le payload (objectif chercher dans le payload les url securisees)
-                $postdata = file_get_contents ("php://input"); 
-             
-                //Seul le post xml de zoo est modifié
-                if (!empty ($postdata) && strpos ($postdata, 'wps:Execute') !== false) {
-                    $doc = new DOMDocument();
-                    $doc->loadXML ($postdata);
-                    $domList = $doc->getElementsByTagNameNS ('*', '*');
-                   //on navigue dans tout le payload
-                    for ($i = 0; $i < $domList->length; $i++) {
-                        if ($domList->item ($i)->tagName === 'wps:Reference') {
-                            $xmlurl = $domList->item ($i)->getAttribute ('xlink:href');
-                            $partsxml = parse_url ($xmlurl);
-                            //les credentials a ajouter dans le xml on verifié s il y en as
-                            if (isset ($xmlurl) && $partsxml['scheme'] === 'https') {
-                                if ($xmlurl !== $url ) {
-                                 //les credentials des urls qu on as pas 
-                                    $authxml = obtenirChaineConnexion ($partsxml['scheme'] . '://' . $partsxml['host'] . $partsxml['path'], $restService=false);
-                                    if (isset ($authxml['user']) && isset ($authxml['pass'])) {
-                                        $urlxml = $partsxml['scheme'] . '://' . $authxml['user'] . ':' . $authxml['pass'] . '@' . $partsxml['host'] . $partsxml['path'] . '?' . $partsxml['query'];
-                                    }
-                                    $xmlpost = str_replace ($xmlurl, $urlxml, $postdata);
-                                    $postdata = $xmlpost;
-                                }
-                                //les credentials de zoo on possede deja dans le xml est modifié
-                                if ($xmlurl === $url) {
-                                    $urlxml = $partsxml['scheme'] . '://' . $auth['user'] . ':' . $auth['pass'] . '@' . $partsxml['host'] . $partsxml['path'];
-                                    $xmlpost = str_replace ($xmlurl, $urlxml, $postdata);
-                                    $postdata = $xmlpost;
-                                }
-                            }
-                        }
-                    }
-
-                    curl_setopt ($ch, CURLOPT_POST, 1);
-                    curl_setopt ($ch, CURLOPT_POSTFIELDS, $postdata);
-                       
-                }
-      
-            	//Necessaire pour le SSL sinon on voit pas les couches dans 
-            	//la list des couche disponible analyse spatial
-            	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 0);
-                curl_setopt($ch, CURLOPT_SSL_VERIFYHOST,  2);
-                
-                                
-                curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
-                curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);  
-                
-                switch ($auth['method']) {
-                    case "BASIC":
-                        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
-                        break;
-                    case "NTLM":
-                        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
-                        break;
-                    case "GSSNEGOTIATE":
-                        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_GSSNEGOTIATE);
-                        break;
-                    case "DIGEST":
-                        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
-                        break;
-                    default:
-                        curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
-                        break;
-                }
-
-                curl_setopt($ch, CURLOPT_USERPWD, $auth['user'] . ':' . $auth['pass']);
-            }
-        }
-
+         $igoController = new IgoController();
+         $ch = $igoController->proxyChaineConnexion($ch, $url, $method, $options);  
+   
+       
+        
         $result = curl_exec ($ch);
         $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
         $http_status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/interfaces/navigateur/app/controllers/IgoController.php
+++ b/interfaces/navigateur/app/controllers/IgoController.php
@@ -336,9 +336,6 @@ class IgoController extends ControllerBase {
     private function obtenirPermisUrl($szUrl, $restService=false){
         //vérifier URL 
         //Services
-   
-        //$f = fopen ('/var/systemes/igo_unit/interfaces/navigateur/api/controller.txt', 'w');
-        //fwrite($f, $szUrl ."\n"); 
         
         $url = "";
 
@@ -350,10 +347,6 @@ class IgoController extends ControllerBase {
   
         $session = $this->getDI()->getSession();
     
-       //fwrite ($f, new Phalcon\Debug\Dump())->variable($session, " session")."\n";
-       //fwrite($f,  var_dump($session) ."\n");
-            
-        
         if($session->has("info_utilisateur") && isset($this->config['permissions'])) {
             //utilisateur
             if(($session->info_utilisateur->identifiant) && isset($this->config->permissions[$session->info_utilisateur->identifiant]) && isset($this->config->permissions[$session->info_utilisateur->identifiant]->servicesExternes)){
@@ -391,7 +384,6 @@ class IgoController extends ControllerBase {
         if (($serviceRep["test"] === false || $serviceRep["url"] === true) && isset($this->config['servicesExternes'])) {
          
             $servicesExternes = $this->config['servicesExternes'];
-           //fwrite($f, implode(",", $servicesExternes) ."\n");
             
             $serviceRep = self::verifieDomaineFunc($serviceRep, $szUrl, $servicesExternes, $restService);
         }
@@ -418,9 +410,6 @@ class IgoController extends ControllerBase {
             }
         }
   
-        
-        //fwrite($f, implode(",", $szUrl) ."\n"); 
-        //fclose ($f);
         return $szUrl;
 
     }

--- a/interfaces/navigateur/app/controllers/IgoController.php
+++ b/interfaces/navigateur/app/controllers/IgoController.php
@@ -408,6 +408,150 @@ class IgoController extends ControllerBase {
 
         return $szUrl;
     }
+    
+     /**
+     * Obtenir Chaine de connexion au site securise
+     * @param ??? $service
+     * @param ??? $restService
+     * @return ??? $auth
+     */
+     
+    public function obtenirChaineConnexion($service, $restService=false){  
+        global $app;
+       
+        $permisUrl = $this->obtenirPermisUrl($service, $restService);
+        
+        if($permisUrl === false){
+            http_response_code(403);
+            die("Vous n'avez pas les droits pour ce service.");
+        } 
+
+       //Decrypter la chaine de connexion
+        if (!empty($permisUrl['connexion']) || !empty($permisUrl['user'])) {
+            $auth = array();
+            if(!empty($permisUrl['user'])) {
+                $auth['user'] = $permisUrl['user']; 
+            }
+            if(!empty($permisUrl['pass'])) {
+                $auth['pass'] = $permisUrl['pass']; 
+            }
+            if(!empty($permisUrl['methode'])) {
+                $auth['method'] = $permisUrl['methode']; 
+            }
+            if(!empty($permisUrl['cainfo'])) {
+                $auth['cainfo'] = $permisUrl['cainfo']; 
+            }
+
+            if(!empty($permisUrl['connexion'])){
+                $crypt = $app->getDI()->get("crypt");
+                $chaine = explode(",", $crypt->decryptBase64(urldecode($permisUrl['connexion'])));
+                $auth['user'] = ltrim(trim($chaine[0]), " user:");
+                $auth['pass'] = ltrim(trim($chaine[1]), " pass:");
+                if (empty($auth['pass'])) {
+                    header('Content-Type: text/html; charset=utf-8');
+                    http_response_code(401);
+                    die("Votre clé n'est pas décryptée correctement.");
+                }
+            }
+           
+        }
+       
+          $auth['url'] = $permisUrl['url'];
+          return $auth; 
+    }
+      
+    
+    /**
+     * Obtenir Chaine de connexion au site securise pour proxy
+     * @param ??? $ch
+     * @param ??? $url
+     * @param ??? $method
+     * @param ??? $url
+     * @return ??? $ch
+     */
+    public function proxyChaineConnexion ($ch, $url, $method, $options) {
+       
+        if (!empty ($options['auth'])) {
+            $auth = $options['auth'];
+            if (isset ($auth['method']) && isset ($auth['user']) && isset ($auth['pass'])) {
+                //On obtient le payload (objectif chercher dans le payload les url securisees)
+                $postdata = file_get_contents ("php://input");
+                //Seul le post xml de zoo est modifié
+                if (!empty ($postdata) && strpos ($postdata, 'wps:Execute') !== false) {
+                    $doc = new DOMDocument();
+                    $doc->loadXML ($postdata);
+                    $domList = $doc->getElementsByTagNameNS ('*', '*');
+                    //on navigue dans tout le payload
+                    for ($i = 0; $i < $domList->length; $i++) {
+                        if ($domList->item ($i)->tagName === 'wps:Reference') {
+                            $xmlurl = $domList->item ($i)->getAttribute ('xlink:href');
+                            $partsxml = parse_url ($xmlurl);
+                            //les credentials a ajouter dans le xml on verifié s il y en as
+                            if (isset ($xmlurl) && $partsxml['scheme'] === 'https') {
+                                if ($xmlurl !== $url) {
+                                    //les credentials des urls qu on as pas 
+                                    $authxml = $this->obtenirChaineConnexion ($partsxml['scheme'] . '://' . $partsxml['host'] . $partsxml['path'], $restService = false);
+                                    if (isset ($authxml['user']) && isset ($authxml['pass'])) {
+                                        $urlxml = $partsxml['scheme'] . '://' . $authxml['user'] . ':' . $authxml['pass'] . '@' . $partsxml['host'] . $partsxml['path'] . '?' . $partsxml['query'];
+                                    }
+                                    $xmlpost = str_replace ($xmlurl, $urlxml, $postdata);
+                                    $postdata = $xmlpost;
+                                }
+                                //les credentials de zoo on possede deja dans le xml est modifié
+                                if ($xmlurl === $url) {
+                                    $urlxml = $partsxml['scheme'] . '://' . $auth['user'] . ':' . $auth['pass'] . '@' . $partsxml['host'] . $partsxml['path'];
+                                    $xmlpost = str_replace ($xmlurl, $urlxml, $postdata);
+                                    $postdata = $xmlpost;
+                                }
+                            }
+                        }
+                    }
+
+                    curl_setopt ($ch, CURLOPT_POST, 1);
+                    curl_setopt ($ch, CURLOPT_POSTFIELDS, $postdata);
+                }
+
+                //Necessaire pour le SSL sinon on voit pas les couches dans 
+                //la list des couche disponible analyse spatial
+               
+                //curl_setopt ($ch, CURLOPT_VERBOSE, 1);
+                //curl_setopt ($ch, CURLOPT_CERTINFO, 1);
+               
+                 if (isset ($auth['cainfo'])) {
+                    curl_setopt ($ch, CURLOPT_CAINFO, $auth['cainfo']);
+                }
+                
+                curl_setopt ($ch, CURLOPT_SSL_VERIFYPEER, 1);
+                curl_setopt ($ch, CURLOPT_SSL_VERIFYHOST, 2);
+              
+                curl_setopt ($ch, CURLOPT_RETURNTRANSFER, true);
+                curl_setopt ($ch, CURLOPT_FOLLOWLOCATION, true);
+                curl_setopt ($ch, CURLOPT_CUSTOMREQUEST, $method);
+
+                switch ($auth['method']) {
+                    case "BASIC":
+                        curl_setopt ($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+                        break;
+                    case "NTLM":
+                        curl_setopt ($ch, CURLOPT_HTTPAUTH, CURLAUTH_NTLM);
+                        break;
+                    case "GSSNEGOTIATE":
+                        curl_setopt ($ch, CURLOPT_HTTPAUTH, CURLAUTH_GSSNEGOTIATE);
+                        break;
+                    case "DIGEST":
+                        curl_setopt ($ch, CURLOPT_HTTPAUTH, CURLAUTH_DIGEST);
+                        break;
+                    default:
+                        curl_setopt ($ch, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+                        break;
+                }
+
+                curl_setopt ($ch, CURLOPT_USERPWD, $auth['user'] . ':' . $auth['pass']);
+            }
+        }
+
+        return $ch;
+    }
 
     private function verifieDomaineRegexFunc($service, $arrayRegex) {
         foreach ($arrayRegex as $regex) {

--- a/interfaces/navigateur/app/controllers/IgoController.php
+++ b/interfaces/navigateur/app/controllers/IgoController.php
@@ -330,12 +330,16 @@ class IgoController extends ControllerBase {
      * vérifie si URL ou nom du service est permis selon config.php.
      */
     public function verifierPermis($szUrl, $restService=false){
-        return obtenirPermisUrl($szUrl, $restService) !== false;
+        return self::obtenirPermisUrl($szUrl, $restService) !== false;
     }
 
-    public function obtenirPermisUrl($szUrl, $restService=false){
+    private function obtenirPermisUrl($szUrl, $restService=false){
         //vérifier URL 
         //Services
+   
+        //$f = fopen ('/var/systemes/igo_unit/interfaces/navigateur/api/controller.txt', 'w');
+        //fwrite($f, $szUrl ."\n"); 
+        
         $url = "";
 
         $serviceRep = array(
@@ -343,7 +347,12 @@ class IgoController extends ControllerBase {
             "test" => false
         );
 
+  
         $session = $this->getDI()->getSession();
+    
+       //fwrite ($f, new Phalcon\Debug\Dump())->variable($session, " session")."\n";
+       //fwrite($f,  var_dump($session) ."\n");
+            
         
         if($session->has("info_utilisateur") && isset($this->config['permissions'])) {
             //utilisateur
@@ -380,7 +389,10 @@ class IgoController extends ControllerBase {
 
         //general
         if (($serviceRep["test"] === false || $serviceRep["url"] === true) && isset($this->config['servicesExternes'])) {
+         
             $servicesExternes = $this->config['servicesExternes'];
+           //fwrite($f, implode(",", $servicesExternes) ."\n");
+            
             $serviceRep = self::verifieDomaineFunc($serviceRep, $szUrl, $servicesExternes, $restService);
         }
 
@@ -405,11 +417,17 @@ class IgoController extends ControllerBase {
                 $szUrl = array("url" => $serviceRep["url"]);    
             }
         }
-
+  
+        
+        //fwrite($f, implode(",", $szUrl) ."\n"); 
+        //fclose ($f);
         return $szUrl;
+
     }
-    
-     /**
+
+
+
+ /**
      * Obtenir Chaine de connexion au site securise
      * @param ??? $service
      * @param ??? $restService
@@ -419,8 +437,8 @@ class IgoController extends ControllerBase {
     public function obtenirChaineConnexion($service, $restService=false){  
         global $app;
        
-        $permisUrl = $this->obtenirPermisUrl($service, $restService);
-        
+        $permisUrl = self::obtenirPermisUrl($service, $restService);
+           
         if($permisUrl === false){
             http_response_code(403);
             die("Vous n'avez pas les droits pour ce service.");
@@ -443,7 +461,7 @@ class IgoController extends ControllerBase {
             }
 
             if(!empty($permisUrl['connexion'])){
-                $crypt = $app->getDI()->get("crypt");
+                $crypt = $this->getDI()->get("crypt");
                 $chaine = explode(",", $crypt->decryptBase64(urldecode($permisUrl['connexion'])));
                 $auth['user'] = ltrim(trim($chaine[0]), " user:");
                 $auth['pass'] = ltrim(trim($chaine[1]), " pass:");
@@ -552,7 +570,6 @@ class IgoController extends ControllerBase {
 
         return $ch;
     }
-
     private function verifieDomaineRegexFunc($service, $arrayRegex) {
         foreach ($arrayRegex as $regex) {
             if ($regex[0] === '#' || $regex[0] === '/') {


### PR DESCRIPTION
Déplacement de fonctions présent du proxy vers `igoController`. Pour permettre accès aux fonctions comme:`obtenirChaineConnexion`, `obtenirPermisUrl` et `proxyChaineConnexion` vers le `igoController` pour être en mesure de les appeler à partir de future modules (php phalcon). Ajout du paramètre de plus dans config `servicesExternes`, `cainfo` pour indiquer l'emplacement physique des fichiers de certificats SSL coté serveur pour un `url` et alimenter `php curl` correctement vers les services WMS sécurisés et en http(s). Ajustement de l'appel `getFeatureInfo` de l'outilInfo pour passé en plus les valeurs qui sont présent dans `extraParams`.
