### PR TITLE
Ajouter un infobulles sur le survol des marqueurs

### DIFF
--- a/interfaces/navigateur/public/js/app/menu/itineraire.js
+++ b/interfaces/navigateur/public/js/app/menu/itineraire.js
@@ -605,7 +605,7 @@ define(['aide', 'panneau', 'vecteur', 'point', 'ligne', 'limites', 'occurence', 
         };
         
         this.vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
-            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.titre});
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.titre, aFermerBouton: false});
         }, 
         {scope: this});
         this.vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){

--- a/interfaces/navigateur/public/js/app/menu/itineraire.js
+++ b/interfaces/navigateur/public/js/app/menu/itineraire.js
@@ -604,6 +604,15 @@ define(['aide', 'panneau', 'vecteur', 'point', 'ligne', 'limites', 'occurence', 
             };
         };
         
+        this.vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.titre});
+        }, 
+        {scope: this});
+        this.vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){
+            e.occurence.fermerInfobulle();
+        }, 
+        {scope: this});
+        
         return occurence;
     };
 

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheAdresse.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheAdresse.js
@@ -128,7 +128,7 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
         };
         
         vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
-            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.adresseLibre});
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.adresseLibre, aFermerBouton: false});
         }, 
         {scope: this});
         vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheAdresse.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheAdresse.js
@@ -126,6 +126,15 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
                 propriete: 'adresseLibre'
             }]
         };
+        
+        vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.adresseLibre});
+        }, 
+        {scope: this});
+        vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){
+            e.occurence.fermerInfobulle();
+        }, 
+        {scope: this});
 
         this.traiterResultatVecteur(vecteur, responseJSON.nombreResultat); 
     };

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
@@ -129,6 +129,15 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
                 propriete: 'adresseLibre'
             }]
         };
+        
+        vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.lieu});
+        }, 
+        {scope: this});
+        vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){
+            e.occurence.fermerInfobulle();
+        }, 
+        {scope: this});
 
         this.traiterResultatVecteur(vecteur, responseJSON.nombreResultat);      
     };

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
@@ -101,9 +101,9 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
             
             $.each(value.placeListe, function(keyPlace, place){
                 if(place.type === 'Municipalité'){
-                    value.lieu = place.nom;
-                } else if (place.type === 'Lieu'){
                     value.municipalite = place.nom;
+                } else if (place.type === 'Lieu'){
+                    value.lieu = place.nom;
                 }
             });
             vecteur.creerOccurence(point, value);
@@ -131,7 +131,7 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
         };
         
         vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
-            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.municipalite});
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.lieu});
         }, 
         {scope: this});
         vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
@@ -131,7 +131,7 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
         };
         
         vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
-            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.lieu});
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.lieu, aFermerBouton: false});
         }, 
         {scope: this});
         vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){

--- a/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/rechercheLieu.js
@@ -131,7 +131,7 @@ define(['recherche', 'aide', 'point', 'style', 'limites'], function(Recherche, A
         };
         
         vecteur.ajouterDeclencheur('occurenceSurvol', function(e){
-            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.lieu});
+            e.occurence.ouvrirInfobulle({html:e.occurence.proprietes.municipalite});
         }, 
         {scope: this});
         vecteur.ajouterDeclencheur('occurenceSurvolFin', function(e){


### PR DESCRIPTION
Ajouter un infobulles sur le survol pour identifier le lieu indiqué par un marqueur.
Fait dans RechercheAdresse, RechercheLieu et Itinéraire selon la pertinence du détails à afficher.
