### PR TITLE
Permettre d'afficher un erreur générique à l'utilisateur quand la couche est en erreur

### DIFF
--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1653,7 +1653,8 @@ Permet la définition d'une couche provenant d’un service de carte (WMS).
 |infoEncodage | Indique l'encodage voulu dans la fenêtre de résultats pour l' *OutilInfo* sur la couche | Non| Chaîne alphanumérique| *UTF-8*|
 |infoGabarit | Indique l'emplacement du script [Handlebars](https://github.com/wycats/handlebars.js#differences-between-handlebarsjs-and-mustache) avec l'extension *.html* qui sera apliqué dans la fenêtre de résultats sur l' *OutilInfo* après le clique sur la couche dans la carte ([exemple](https://github.com/bosthy/igo/blob/dev/interfaces/navigateur/public/template/handlebars.exemple.html),[ exemple simple](https://github.com/bosthy/igo/blob/dev/interfaces/navigateur/public/template/handlebars.exempleSimple.html)) | Non|  URL|
 |infoUrl | Indique un url qui sera remplacer par l'url GetFeaturInfo de l' *OutilInfo* | Non| URL| |
-|infoAction | Indique l'emplacement du script qui reçevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL|		|
+|infoAction | Indique l'emplacement du script qui reçevra le résultats json du GetFeatureInfo de l' *OutilInfo* après le clique sur la couche dans la carte l'affichage sera géré par le script| Non| URL| |
+|afficherMessageErreurUtilisateur| Permettre d'afficher un message générique à l'utilisateur quand la couche est en erreur. | Non | "True" | |
 
 *Exemples*
 ```xml

--- a/interfaces/navigateur/public/js/app/couche/protocole/WMS.js
+++ b/interfaces/navigateur/public/js/app/couche/protocole/WMS.js
@@ -332,6 +332,8 @@ define(['couche', 'aide', 'browserDetect'], function(Couche, Aide, BrowserDetect
     };
     
     WMS.prototype._validerChargement = function(e, a){
+        var that = this;
+        
         if(e.object.div.innerHTML.indexOf("olImageLoadError")>-1){
             $.ajax({
                 url: Aide.utiliserProxy(decodeURIComponent($('<textarea/>').html(/src="(.*)"/.exec(e.object.div.innerHTML)[1]).text())),
@@ -343,6 +345,12 @@ define(['couche', 'aide', 'browserDetect'], function(Couche, Aide, BrowserDetect
                 async:false,
                 context:this,
                 success:function(response) {
+                    
+                    if(this.options.afficherMessageErreurUtilisateur === "true"){
+                       this.gestionErreurWMS(this);
+                       return false;
+                    }
+                    
                     var message = '<b>'+this.options.titre +':</b><br>';
                     
                     if(typeof response === 'object'){        
@@ -357,19 +365,7 @@ define(['couche', 'aide', 'browserDetect'], function(Couche, Aide, BrowserDetect
                     }
                 },
                 error:function(e){
-                    var message = '<b>'+ e.statusText +':</b><br>';
-                    Aide.afficherMessageConsole(message);
-                    /*var response = e.responseXML;
-                    
-                    if(typeof response === 'object'){     
-                        var tagError = response.getElementsByTagName("ServiceException");
-                        if(tagError){
-                            message += tagError.item(0).textContent;
-                            Aide.afficherMessageConsole(message);
-                        }
-                    } else {
-                        Aide.afficherMessageConsole(message);
-                    }*/
+                  that.gestionErreurWMS(e);
                 }
             
             });
@@ -379,6 +375,18 @@ define(['couche', 'aide', 'browserDetect'], function(Couche, Aide, BrowserDetect
     WMS.prototype.rafraichir = function() { 
         if(this._layer){
             this._layer.redraw(true);  
+        }
+    };
+    
+    WMS.prototype.gestionErreurWMS = function(e) {
+        
+        if(this.options.afficherMessageErreurUtilisateur === "true") {
+            Aide.afficherMessage({titre: this.obtenirGroupe(), message: "La couche d'information " + this.obtenirTitre() + " n'est actuellement pas disponible."});
+            this.desactiver();
+        }
+        else {      
+            var message = '<b>'+ e.statusText +':</b><br>';
+            Aide.afficherMessageConsole(message);
         }
     };
     


### PR DESCRIPTION
Permettre d'afficher un erreur générique à l'utilisateur quand la couche est en erreur.

Effectif seulement pour les WMS
