### PR TITLE
Retirer la méthode qui est là en double

### DIFF
--- a/interfaces/navigateur/public/js/app/couche/gestionCouches.js
+++ b/interfaces/navigateur/public/js/app/couche/gestionCouches.js
@@ -459,25 +459,7 @@ define(['evenement', 'couche', 'blanc', 'limites', 'aide'], function(Evenement, 
                 couche.desactiver();
             }
         }); 
-    };
-    
-    /**
-     * Désélectionner toutes les couches WMTS qui ne sont pas des fonds de carte
-     * @method
-     * @name GestionCouches#deselectionnerCouchesWMTS
-     * 
-     */
-    GestionCouches.prototype.deselectionnerCouchesWMTS = function(){
-      
-        var tabCouches = this.obtenirCouchesParType("WMTS");
-        
-        $.each(tabCouches, function(index, couche){
-                
-            if(!couche.estFond() && couche.estActive()){
-                couche.desactiver();
-            }
-        }); 
-    };
+    };    
       
     /** 
      * Création de l'object GestionCouches.Controles


### PR DESCRIPTION
La méthode deselectionnerCouchesWMTS est en double dans le fichier.
