### PR TITLE
Correction des outils outilAssocierFichier et outilImportFichier

### DIFF
--- a/interfaces/navigateur/public/js/app/outil/outilAssocierFichier.js
+++ b/interfaces/navigateur/public/js/app/outil/outilAssocierFichier.js
@@ -69,10 +69,10 @@ define(['aide', 'outil', 'fileUploadField'], function(Aide, Outil) {
             html: "<div style=\"position:absolute;top:115px;left:25px;\" id=\"uploadForm\"></div>"
         });
 
-        var buttonVisualiser = new Ext.Button({
+        var buttonTelecharger = new Ext.Button({
             width: 80,
             cls: "fileButton",
-            text: "Visualiser",
+            text: "Télécharger",
             listeners : {
                 click : function(){
                     
@@ -123,11 +123,11 @@ define(['aide', 'outil', 'fileUploadField'], function(Aide, Outil) {
             style: "position: relative; float:right",
             cls: "uploadForm",
             width: 80,
-            items: [buttonVisualiser,
+            items: [buttonTelecharger,
                 {
                     xtype :'fileuploadfield',
                     inputType :'file',
-                    id: 'uploadDocument',
+                    id: 'uploadOutilAssocierFichier',
                     buttonOnly : true,
                     buttonText: "&nbsp; &nbsp; &nbsp; Ajouter&nbsp; &nbsp; &nbsp;&nbsp;", //width 80?
                     cls: "fileButton",

--- a/interfaces/navigateur/public/js/app/outil/outilImportFichier.js
+++ b/interfaces/navigateur/public/js/app/outil/outilImportFichier.js
@@ -140,7 +140,7 @@ define(['outil', 'aide', 'analyseurGeoJSON', 'vecteur', 'togeojson', 'fileUpload
                     anchor: '95%',
                     allowBlank: false,
                     xtype: 'fileuploadfield',                   
-                    id: 'upload',
+                    id: 'uploadOutilImportFichier',
                     emptyText: 'Sélectionner un fichier...',
                     fieldLabel: 'Fichier',
                     buttonText: 'Parcourir',
@@ -271,7 +271,7 @@ define(['outil', 'aide', 'analyseurGeoJSON', 'vecteur', 'togeojson', 'fileUpload
                             var data = new FormData();
                             
                             //Obtenir le fichier d'upload
-                            var file = jQuery('input[id^="upload"]')[1].files[0];
+                            var file = jQuery('input[id^="uploadOutilImportFichier"]')[1].files[0];
                             var extension = file.name.split(".")[file.name.split(".").length-1];
                             var filename = file.name.split(".")[0];
                             //Exception pour le format GPX, le service ogre ne fonctionne pas bien, on utilise donc togeojson
@@ -295,7 +295,7 @@ define(['outil', 'aide', 'analyseurGeoJSON', 'vecteur', 'togeojson', 'fileUpload
                                 data.append('upload', file);
 
                                 //Ne pas afficher les erreurs
-                                //data.append("skipFailures",'');
+                                data.append("skipFailures",'');
 
                                //Projection de la carte
                                 //data.append("targetSrs", that.projection);
@@ -403,6 +403,27 @@ define(['outil', 'aide', 'analyseurGeoJSON', 'vecteur', 'togeojson', 'fileUpload
                             feat.geometry.coordinates.splice(posToPop, 1);
                         });         
                     }
+                }
+                
+                //Illiminé les doublons de coordonnées pour chaque géométrie de type polygone
+                if(feat.geometry.type === "Polygon")
+                {
+                    var coordPrec = "";
+                    var coordIndexToPop = new Array();
+                    $.each(feat.geometry.coordinates, function(index, geom){
+                        $.each(geom, function(ind, coord){                   
+                        //Si égale à la coordonnée précédente
+                            if(coordPrec !== "" && coordPrec[0] === coord[0] && coordPrec[1] === coord[1]){
+                                coordIndexToPop.push(ind);
+                        }else{
+                            //Sinon si coordonnée à 3dimensions, on retire la dimension "z"
+                            if(coord.length === 3) {
+                                coord.pop();
+                            }
+                            }                 
+                            coordPrec = coord;    
+                        });  
+                    });
                 }
             }
         });


### PR DESCRIPTION
Changer les libellés des boutons de l'outil AssocierFichier
Changer les id du fileuploadfield afin de ne pas avoir de conflit entre les outils outilAssocierFichier et OutilImportFichier
Illiminer les doublons de coordonnées pour chaque géométrie de type polygone lors de l'import et retirer la dimension z
