### PR TITLE
Message d'erreur lors de la connection LDAP et Lien vers l'aide en option

### DIFF
--- a/interfaces/navigateur/public/js/app/menu/recherche/recherche.js
+++ b/interfaces/navigateur/public/js/app/menu/recherche/recherche.js
@@ -23,6 +23,7 @@ define(['panneau', 'vecteur', 'aide', 'panneauTable', 'css!css/recherche'], func
      * @requires recherche
      * @param {string} [options.recherchePrefixe] Prefixe de la recherche
      * @param {string} [options.typeRecherche] Type de la recherche
+     * @param {string} [options.lienAide] Lien URL vers une aide 
      * @returns {Panneau.Recherche} Instance de {@link Panneau.Recherche}
      * @property {dictionnaire} options Liste des options de la couche
      * @property {Couche.Vecteur} vecteur Vecteur pour le résultat de la recherche
@@ -39,7 +40,8 @@ define(['panneau', 'vecteur', 'aide', 'panneauTable', 'css!css/recherche'], func
             sauvegarder: true,
             id: 'recherche',
             init: false,
-            zoom: 15
+            zoom: 15,
+            lienAide: Aide.utiliserBaseUri("guides/IGO_Navigateur_guide.pdf")
         };
     };
 
@@ -155,7 +157,7 @@ define(['panneau', 'vecteur', 'aide', 'panneauTable', 'css!css/recherche'], func
      */
     Recherche.prototype.obtenirLienPDF = function() {
         return  "<a href=\'#here\' onclick=\'window.open(\"" +
-                Aide.utiliserBaseUri("guides/IGO_Navigateur_guide.pdf") +
+                this.obtenirLienAide() +
                 "\");\'>" +
                 "Cliquer ici pour avoir plus de détails...</a><br><br>";
     };
@@ -632,6 +634,10 @@ define(['panneau', 'vecteur', 'aide', 'panneauTable', 'css!css/recherche'], func
             this.definirResultat(this.obtenirAideHTML());
         }
     };
+
+    Recherche.prototype.obtenirLienAide = function (){
+        return (typeof this.options.lienAide == undefined)?this.defautOptions.lienAide:this.options.lienAide;
+    }
     
     return Recherche;
 

--- a/services/igo_commun/app/controllers/AuthentificationController.php
+++ b/services/igo_commun/app/controllers/AuthentificationController.php
@@ -7,7 +7,7 @@ abstract class AuthentificationController extends Controller{
      * Fonction retournant le dernier message d'erreur à afficher 
      * en cas d'erreur lors de l'authentification.
      */
-    abstract public function obtenirMessageErreur();        
+    abstract public function obtenirMessagesErreur();        
 
     /*
      * Fonction publique permettant l'authentification à un serveur LDAP.

--- a/services/igo_commun/app/controllers/AuthentificationExterne.php
+++ b/services/igo_commun/app/controllers/AuthentificationExterne.php
@@ -11,9 +11,9 @@ class AuthentificationExterne extends AuthentificationController {
     protected $igo_utilisateur;
     protected $nom;
     protected $prenom;
-    protected $messageErreur = "Erreur d'authentification";
+    protected $messageErreur = ["Erreur d'authentification"];
 
-    public function obtenirMessageErreur() {
+    public function obtenirMessagesErreur() {
         return $this->messageErreur;
     }
 

--- a/services/igo_commun/app/controllers/AuthentificationLdap.php
+++ b/services/igo_commun/app/controllers/AuthentificationLdap.php
@@ -12,10 +12,10 @@ class AuthentificationLdap extends AuthentificationController {
     protected $prenom;
     protected $nom;
     
-    protected $messageErreur = "";
+    protected $messagesErreur = [];
 
-    public function obtenirMessageErreur(){
-        return $this->messageErreur;
+    public function obtenirMessagesErreur(){
+        return $this->messagesErreur;
     }
 
     /*
@@ -39,8 +39,8 @@ class AuthentificationLdap extends AuthentificationController {
     /*
      * Fonction publique permettant l'authentification à un serveur LDAP.
      * Paramètres : identifiant, mot de passe
-     * Définit un message d'erreur dans la variable $this->messageErreur
-     * $this->messageErreur est utilisé pour afficher un message expliquant
+     * Définit un message d'erreur dans la variable $this->messagesErreur
+     * $this->messagesErreur est utilisé pour afficher un message expliquant
      * pourquoi l'authentification à échouée.
      */
     public function authentification($identifiant, $motDePasse){
@@ -49,13 +49,13 @@ class AuthentificationLdap extends AuthentificationController {
         
         /* On s'authentifie dans le LDAP */
         $this->authentifierLDAP($identifiant, $motDePasse);
-    
+        
         if($this->motDePasseExpire){
-            $this->messageErreur = "Votre mot de passe est expiré. Veuillez le changer pour avoir accès au système!";
+            $this->messagesErreur[] = "Votre mot de passe est expiré. Veuillez le changer pour avoir accès au système!";
             return false;
         }
         if(!$this->motDePasseValide){
-            $this->messageErreur = "L'authentification a échouée.";            
+            $this->messagesErreur[] = "L'authentification a échouée.";            
         }
 
         if($this->motDePasseValide) {
@@ -215,6 +215,11 @@ class AuthentificationLdap extends AuthentificationController {
             $ldapbind2 = ldap_bind($ldapcon2, $userEntries[0]["dn"], $motDePasse);
         }
         $this->motDePasseValide = $ldapbind2;
+
+        if($this->motDePasseValide){
+            $this->messagesErreur = [];
+        }
+
     }
 
     public function obtenirNom(){

--- a/services/igo_commun/app/controllers/AuthentificationLdap.php
+++ b/services/igo_commun/app/controllers/AuthentificationLdap.php
@@ -212,7 +212,7 @@ class AuthentificationLdap extends AuthentificationController {
         if(strlen($motDePasse) == 0){
             $ldapbind2 = false;
         }else{
-            $ldapbind2 = ldap_bind($ldapcon2, $userEntries[0]["dn"], $motDePasse);
+            $ldapbind2 = @ldap_bind($ldapcon2, $userEntries[0]["dn"], $motDePasse);
         }
         $this->motDePasseValide = $ldapbind2;
 

--- a/services/igo_commun/app/controllers/AuthentificationLdapBasic.php
+++ b/services/igo_commun/app/controllers/AuthentificationLdapBasic.php
@@ -21,21 +21,16 @@ class AuthentificationLdapBasic extends AuthentificationLdap {
      */
     public function authentification($identifiant, $motDePasse) {
         $valide = false;
-        $ignorerErreurs = false;
 
         if($identifiant === null && $motDePasse === null) {
            if(isset($_SERVER['PHP_AUTH_USER']) && isset($_SERVER['PHP_AUTH_PW'])) {
               $identifiant = trim($_SERVER['PHP_AUTH_USER']);
               $motDePasse = trim($_SERVER['PHP_AUTH_PW']);
-           } else {
-              $ignorerErreurs = true;
-           }
+           } 
         }
 
-        $valide = parent::authentification($identifiant, $motDePasse);
-
-        if($ignorerErreurs) {
-           $this->messageErreur = "";
+        if($identifiant !== null && $motDePasse !== null) {
+          $valide = parent::authentification($identifiant, $motDePasse);
         }
 
         return $valide;

--- a/services/igo_commun/app/controllers/AuthentificationTest.php
+++ b/services/igo_commun/app/controllers/AuthentificationTest.php
@@ -6,11 +6,11 @@ class AuthentificationTest extends AuthentificationController {
     protected $profils;
     protected $motDePasseValide;
     protected $motDePasseExpire;
-    protected $messageErreur = "";
+    protected $messageErreur = [];
     protected $nom;
     protected $prenom;
 
-    public function obtenirMessageErreur() {
+    public function obtenirMessagesErreur() {
         return $this->messageErreur;
     }
 

--- a/services/igo_commun/app/controllers/ConnexionController.php
+++ b/services/igo_commun/app/controllers/ConnexionController.php
@@ -5,16 +5,21 @@ class ConnexionController extends Controller{
     
     public function indexAction() {
         $authentificationModule = $this->getDI()->get("authentificationModule");        
-
+        
         $configuration = $this->getDI()->get("config");
         if(isset($configuration->application->authentification->authentificationExterne) && $configuration->application->authentification->authentificationExterne){
+            
             $succes = $authentificationModule->authentification(null, null);
+          
             if (!$succes) {
-                $this->session->set("erreur", $authentificationModule->obtenirMessageErreur());
+                
+                $this->setSessionErrors();
+              
                 if(isset($configuration->application->authentification->authentificationUri)){
                     return $this->response->redirect($configuration->application->authentification->authentificationUri, TRUE);
                 }
             } else {
+
                 if (!$this->session->has("info_utilisateur")) {
                     $utilisateur = new SessionController();
                     $this->session->set("info_utilisateur", $utilisateur);
@@ -29,7 +34,7 @@ class ConnexionController extends Controller{
                 $this->session->get("info_utilisateur")->estAnonyme  = false; 
             }              
         }
-            
+         
          //Vérifier si on doit se rappeler où on voulait aller
         $request = new Phalcon\Http\Request();
         $uri = $request->getURI();
@@ -40,18 +45,20 @@ class ConnexionController extends Controller{
         
         //L'utilisateur est déjà authentifié
         if($authentificationModule->estAuthentifie()){
+       
             //Passer à la page de choix du profil
             return $this->dispatcher->forward(array(
                 "action" => "role"
             ));
         }
-        
+       
         //Paramètres pour l'affichage de la page de connexion
         $this->view->setVar("titre", "Authentification");
-        if($this->session->has("erreur")){
-            $this->view->setVar("erreur", $this->session->get("erreur"));
+    
+        if($this->session->has("erreurs")){
+            $this->setSessionErrors();
         }else{
-            $this->view->setVar("erreur", "");
+            $this->view->setVar("erreurs", []);
         }
         
         $this->view->setVar("permettreAccesAnonyme", $configuration->application->authentification->permettreAccesAnonyme);
@@ -73,8 +80,11 @@ class ConnexionController extends Controller{
             $password = $request->getPost('password', null);
             $succes = $this->getDI()->get("authentificationModule")->authentification($username, $password);
             if (!$succes) {
-                $this->session->set("erreur", $this->getDI()->get("authentificationModule")->obtenirMessageErreur());
+                $this->setSessionErrors();
                 return $this->redirigeVersPage();
+            }
+            else{
+                $this->deleteSessionErrors();
             }
 
             if (!$this->session->has("info_utilisateur")) {
@@ -94,7 +104,7 @@ class ConnexionController extends Controller{
                     isset($configuration->application->estPilotage) && 
                     $configuration->application->estPilotage === true) {
                 $this->session->remove("info_utilisateur");
-                $this->session->set("erreur", "Droits insuffisants");
+                $this->session->setSessionErrors(["Droits insuffisants"]);
                 return $this->redirigeVersPage();
             }
 
@@ -279,6 +289,30 @@ class ConnexionController extends Controller{
         }else{
             $this->session->remove('page');
         }
+    }
+
+    private function setSessionErrors($erreurs = []){
+
+        $sessionErrors = [];
+        if($this->session->has('erreurs')){
+            $sessionErrors = $this->session->get('erreurs');
+            if(is_string($sessionErrors)){
+                $sessionErrors = [$sessionErrors];
+            }
+        }
+
+        $authErrors = $this->getDI()->get("authentificationModule")->obtenirMessagesErreur();
+
+        $errorsMerge = array_unique(array_merge($sessionErrors, $authErrors, $erreurs),SORT_LOCALE_STRING);
+
+        $this->session->set("erreurs", $errorsMerge);
+        $this->view->setVar("erreurs", $errorsMerge);
+
+    }
+
+    private function deleteSessionErrors(){
+        $this->session->set("erreurs", []);
+        $this->view->setVar("erreurs", []);
     }
     
 }

--- a/services/igo_commun/app/controllers/ConnexionController.php
+++ b/services/igo_commun/app/controllers/ConnexionController.php
@@ -13,7 +13,7 @@ class ConnexionController extends Controller{
           
             if (!$succes) {
                 
-                $this->setSessionErrors();
+                $this->setErrors();
               
                 if(isset($configuration->application->authentification->authentificationUri)){
                     return $this->response->redirect($configuration->application->authentification->authentificationUri, TRUE);
@@ -56,9 +56,9 @@ class ConnexionController extends Controller{
         $this->view->setVar("titre", "Authentification");
     
         if($this->session->has("erreurs")){
-            $this->setSessionErrors();
+            $this->setErrors();
         }else{
-            $this->view->setVar("erreurs", []);
+            $this->deleteErrors();
         }
         
         $this->view->setVar("permettreAccesAnonyme", $configuration->application->authentification->permettreAccesAnonyme);
@@ -80,11 +80,11 @@ class ConnexionController extends Controller{
             $password = $request->getPost('password', null);
             $succes = $this->getDI()->get("authentificationModule")->authentification($username, $password);
             if (!$succes) {
-                $this->setSessionErrors();
+                $this->setErrors();
                 return $this->redirigeVersPage();
             }
             else{
-                $this->deleteSessionErrors();
+                $this->deleteErrors();
             }
 
             if (!$this->session->has("info_utilisateur")) {
@@ -104,7 +104,7 @@ class ConnexionController extends Controller{
                     isset($configuration->application->estPilotage) && 
                     $configuration->application->estPilotage === true) {
                 $this->session->remove("info_utilisateur");
-                $this->session->setSessionErrors(["Droits insuffisants"]);
+                $this->session->setErrors(["Droits insuffisants"]);
                 return $this->redirigeVersPage();
             }
 
@@ -291,7 +291,13 @@ class ConnexionController extends Controller{
         }
     }
 
-    private function setSessionErrors($erreurs = []){
+    /**
+     * Défini les erreurs dans la session et la variable "erreurs" pour la vue.
+     * 
+     * @param  array $erreurs Tableau d'erreurs à ajouter
+     */
+
+    private function setErrors($erreurs = []){
 
         $sessionErrors = [];
         if($this->session->has('erreurs')){
@@ -310,7 +316,11 @@ class ConnexionController extends Controller{
 
     }
 
-    private function deleteSessionErrors(){
+    /**
+     * Supprime les erreurs dans la session et la variable erreurs pour la vue
+     */
+
+    private function deleteErrors(){
         $this->session->set("erreurs", []);
         $this->view->setVar("erreurs", []);
     }

--- a/services/igo_commun/app/views/connexion/index.volt
+++ b/services/igo_commun/app/views/connexion/index.volt
@@ -1,8 +1,10 @@
 <div class="col-xs-12 col-sm-10 col-sm-offset-1 col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2 bloc-connexion">
     <div class="row">
-        {% if erreur !== "" %}
-        <div class="alert alert-danger text-center col-xs-12 col-md-10 col-md-offset-1 col-lg-10 col-lg-offset-1 login_error" role="alert">{{erreur}}</div>
-        {% endif  %}
+        {% if erreurs is iterable %}
+          {% for erreur in erreurs %}
+          <div class="alert alert-danger text-center col-xs-12 col-md-10 col-md-offset-1 col-lg-10 col-lg-offset-1 login_error" role="alert">{{erreur}}</div>
+          {% endfor %}
+        {%endif%}
     </div>
     <form method='post' action="{{roleUri}}">
         <div class="row">


### PR DESCRIPTION
- Changer de string à array les erreurs possibles de connexions et modifier la vue en conséquence.
- Enlever le warning dans le cas de mot de passe invalide

Ceci permet d,afficher correctement le message d'erreur d'un mot de passe périmé lorsque la connexion externe est utilisée, sinon nous avions un seul est unique message d'erreur "L'authentification a échoué".
