### PR TITLE
Fix l'ajout de WMS en HTTPs au MSP

### DIFF
--- a/interfaces/navigateur/public/libs/GeoExt.ux/WMSBrowser/widgets/tree/WMSBrowserRootNode.js
+++ b/interfaces/navigateur/public/libs/GeoExt.ux/WMSBrowser/widgets/tree/WMSBrowserRootNode.js
@@ -9,14 +9,6 @@
 
 Ext.namespace("GeoExt.ux.tree");
 
-
-	// Bogue fixe MSP, Nicolas 5 fev 2011
-        
-        //todo: changer url_init_msp et prendre le premier url dans liste.
-	var url_init_msp =  Igo.nav.barreOutils.obtenirOutilsParType('OutilAjoutWMS')[0]._MyWMSBrowser.Store.data.first().data.url+ "?service=WMS&request=GetCapabilities&version=1.1.1";
-	url_init_msp = Igo.Aide.utiliserProxy(url_init_msp);
-    // If IE, régler un bogue
-
 /*
  * @requires widgets/WMSBrowser.js
  * @requires widgets/tree/WMSBrowserTreePanel.js
@@ -53,6 +45,10 @@ GeoExt.ux.tree.WMSBrowserRootNode = Ext.extend(Ext.tree.AsyncTreeNode, {
     /** private: method[constructor]
      */
     constructor: function(config) {
+
+        var url_init_msp =  Igo.nav.barreOutils.obtenirOutilsParType('OutilAjoutWMS')[0]._MyWMSBrowser.Store.data.first().data.url+ "?service=WMS&request=GetCapabilities&version=1.1.1";
+        url_init_msp = Igo.Aide.utiliserProxy(url_init_msp);
+
         Ext.apply(this, config);
         Ext.apply(this, {loader: new GeoExt.tree.WMSCapabilitiesLoader({
             //url: "__foo__",


### PR DESCRIPTION
Avec ce fix, nous pouvons forcer un requirejs([WMSBriwserBuild]) et ensuite redéfinir 'addLayer()' et forcer de passer par un proxy
