### PR TITLE
Ajustement IE

### DIFF
--- a/interfaces/navigateur/app/views/index.volt
+++ b/interfaces/navigateur/app/views/index.volt
@@ -3,13 +3,14 @@
 To change this license header, choose License Headers in Project Properties.
 To change this template file, choose Tools | Templates
 and open the template in the editor.
+The X-UA-Compatible meta element must be the first meta element in the head section.
 -->
 <html>
     <head>
         <title>{{titre}}</title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">        
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width"> 
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <link rel="icon" href="{{ view.ajouterBaseUri() }}images/quebec/favicon.ico" />
     </head>
     <body>  


### PR DESCRIPTION
Le meta sur la compatibilité IE doit être le premier tag pour être bien pris en charge par le navigateur