### PR TITLE
Standardiser le bouton avec le même libellé "Réinitialiser" que ce qui est déjà dans les recherches

### DIFF
--- a/interfaces/navigateur/public/js/app/menu/impression.js
+++ b/interfaces/navigateur/public/js/app/menu/impression.js
@@ -224,7 +224,7 @@ define(['panneau', 'aide', 'browserDetect'], function(Panneau, Aide, BrowserDete
                 that.imprimerCarte();               
             }
         },{
-            text: 'Restaurer',
+            text: 'Réinitialiser',
             tooltip: 'Réinitialiser les valeurs des champs',
             handler: function(){
                 that.printForm.getForm().reset();


### PR DESCRIPTION
Selon le commentaire de notre pilote
Standardiser le bouton avec le même libellé "Réinitialiser" que ce qui est déjà dans les recherches