### PR TITLE
Fix authentification

### DIFF
--- a/services/igo_commun/app/controllers/ConnexionController.php
+++ b/services/igo_commun/app/controllers/ConnexionController.php
@@ -14,7 +14,7 @@ class ConnexionController extends Controller{
 
             if (!$succes) {
 
-                $this->setErrors();
+                $this->setErrors($authentificationModule->obtenirMessagesErreur());
 
                 if(isset($configuration->application->authentification->authentificationUri)){
                     return $this->response->redirect($configuration->application->authentification->authentificationUri, TRUE);
@@ -58,7 +58,7 @@ class ConnexionController extends Controller{
         $this->view->setVar("titre", "Authentification");
 
         if($this->session->has("erreurs")){
-            $this->setErrors();
+            $this->setErrors($authentificationModule->obtenirMessagesErreur());
         }else{
             $this->deleteErrors();
         }
@@ -88,7 +88,7 @@ class ConnexionController extends Controller{
             $succes = $authentificationModule->authentification($username, $password);
 
             if (!$succes) {
-                $this->setErrors();
+                $this->setErrors($authentificationModule->obtenirMessagesErreur());
                 return $this->redirigeVersPage();
             }
             else{
@@ -351,8 +351,7 @@ class ConnexionController extends Controller{
             }
         }
 
-        $authErrors = $this->getDI()->get("authentificationModule")->obtenirMessagesErreur();
-        $errorsMerge = array_unique(array_merge($sessionErrors, $authErrors, $erreurs),SORT_LOCALE_STRING);
+        $errorsMerge = array_unique(array_merge($sessionErrors,$erreurs),SORT_LOCALE_STRING);
 
         $this->session->set("erreurs", $errorsMerge);
         $this->view->setVar("erreurs", $errorsMerge);

--- a/services/igo_commun/app/controllers/ConnexionController.php
+++ b/services/igo_commun/app/controllers/ConnexionController.php
@@ -47,7 +47,7 @@ class ConnexionController extends Controller{
 
         //L'utilisateur est déjà authentifié
         if($authentificationModule->estAuthentifie()){
-            
+
             //Passer à la page de choix du profil
             return $this->dispatcher->forward(array(
                 "action" => "role"
@@ -62,12 +62,12 @@ class ConnexionController extends Controller{
         }else{
             $this->deleteErrors();
         }
-       
+
         //Obtenir le nom du configuration XML ouvert et mettre dans la session
         if(!isset ($this->getDI()->get('session')->configuration)){
             $this->getDI()->get('session')->configuration =  $this->getDI()->get('dispatcher')->getParam("configuration");
         }
-        
+
         $this->view->setVar("permettreAccesAnonyme", $configuration->application->authentification->permettreAccesAnonyme);
         $this->view->setVar("roleUri", $configuration->application->baseUri. "connexion/role");
         $this->view->setVar("anonymeUri", $configuration->application->baseUri. "connexion/anonyme");
@@ -75,7 +75,7 @@ class ConnexionController extends Controller{
     }
 
     public function roleAction() {
-        
+
         $authentificationModule = $this->getDI()->get("authentificationModule");
         $configuration = $this->getDI()->get("config");
         $this->view->setVar("titre", "Choix du profil");
@@ -86,6 +86,7 @@ class ConnexionController extends Controller{
             $username = $request->getPost('username', null);
             $password = $request->getPost('password', null);
             $succes = $authentificationModule->authentification($username, $password);
+
             if (!$succes) {
                 $this->setErrors();
                 return $this->redirigeVersPage();
@@ -252,6 +253,9 @@ class ConnexionController extends Controller{
                         $this->session->get("info_utilisateur")->profils = array($profilAnonyme->toArray());
                         $this->session->get("info_utilisateur")->profilActif = $this->session->get("info_utilisateur")->profils[0]['id'];
                     }
+                    else{
+                      $this->session->get("info_utilisateur")->profilActif = $nomProfilAnonyme;
+                    }
                 } else {
                     $this->session->get("info_utilisateur")->profils = IgoProfil::find("nom = '{$nomProfilAnonyme}'")->toArray();
                 }
@@ -260,6 +264,26 @@ class ConnexionController extends Controller{
         }
         else if (isset($configuration->application->authentification->profilAnonyme->pageRedirection) && $estAuthentifier){
             $this->definirPageRedirection($configuration->application->authentification->profilAnonyme->pageRedirection);
+            $nomProfilAnonyme = null;
+            //Paramétrer le profilActif comme Anonyme si null sinon boucle infini
+            if($this->session->get('info_utilisateur')->profilActif===null){
+
+              if($this->session->get('nomProfilAnonyme')==null){
+                $nomProfilAnonyme = $configuration->application->authentification->profilAnonyme->nom;
+              }
+              else{
+                $nomProfilAnonyme = $this->session->get('nomProfilAnonyme');
+              }
+
+              if($nomProfilAnonyme === null){
+                $this->dispatcher->forward(array(
+                    "controller" => "error",
+                    "action" => "error403"
+                ));
+              }
+            }
+
+            $this->session->get("info_utilisateur")->profilActif = $nomProfilAnonyme;
             return $this->redirigeVersPage();
         }
         else {
@@ -328,7 +352,6 @@ class ConnexionController extends Controller{
         }
 
         $authErrors = $this->getDI()->get("authentificationModule")->obtenirMessagesErreur();
-
         $errorsMerge = array_unique(array_merge($sessionErrors, $authErrors, $erreurs),SORT_LOCALE_STRING);
 
         $this->session->set("erreurs", $errorsMerge);


### PR DESCRIPTION
1- régle le problème de boucle infini dans le cas d'un user authentifié mais sans profil valide. (ex tsgeo)  
2- règle les messages d'erreurs LDAP qui n'apparaissent pas. Le module d'authentification n'est plus 'shared' donc instancié à chaque fois donc messages d'erreurs perdus dans setErrors().  
  
S.T.à.P : vérifier si l'utilisation de setShared() dans services.php pour les modules d'authentification causerait problème. Serait plus logique, d'avoir une seule instanciation de chaque modules d'authentification. 