### PR TITLE
Couche

### DIFF
--- a/doc/xml/DocumentationXML.markdown
+++ b/doc/xml/DocumentationXML.markdown
@@ -1514,6 +1514,7 @@ Marqueurs, OSM, TMS, Vecteur, WMS*.
 |metadonnee| Lien vers les métadonnées			| Non		| URL			|		|
 |ordreArborescence| Ordre d'affichage de la couche dans le groupe de l'arborescence (1 étant le haut du groupe)| Non| Nombre entier|
 |estInterrogeable|Indique si le getInfo doit être fait sur cette couche | Non | Booléen | true |
+|excluExport|Indique si on doit exclure la couche pour l'outil d'export | Non | Booléen | false |
 
 blanc
 -----

--- a/interfaces/navigateur/public/js/app/outil/outilExportFichier.js
+++ b/interfaces/navigateur/public/js/app/outil/outilExportFichier.js
@@ -508,7 +508,7 @@ define(['outil', 'occurence', 'aide', 'analyseurGeoJSON', 'togpx', 'multiSelect'
         var dataCouche = [["_selection", "Éléments sélectionnés"]];
         $.each(listeObjCouche, function(index, objCouche){
             
-            if(typeof objCouche.options.excluExport === undefined || (objCouche.options.excluExport !== "true" && objCouche.options.excluExport !== true))  {          
+            if((typeof objCouche.options.excluExport === "undefined" || (objCouche.options.excluExport !== "true" && objCouche.options.excluExport !== true)) && typeof objCouche.options.visible === "undefined" || (objCouche.options.excluExport === "true" || objCouche.options.excluExport === true))  {          
             dataCouche.push([objCouche.id, objCouche.options.titre]);
             }
         });

--- a/interfaces/navigateur/public/js/app/outil/outilExportFichier.js
+++ b/interfaces/navigateur/public/js/app/outil/outilExportFichier.js
@@ -507,7 +507,10 @@ define(['outil', 'occurence', 'aide', 'analyseurGeoJSON', 'togpx', 'multiSelect'
         
         var dataCouche = [["_selection", "Éléments sélectionnés"]];
         $.each(listeObjCouche, function(index, objCouche){
+            
+            if(typeof objCouche.options.excluExport === undefined || (objCouche.options.excluExport !== "true" && objCouche.options.excluExport !== true))  {          
             dataCouche.push([objCouche.id, objCouche.options.titre]);
+            }
         });
         
         var asListeCouche = new Ext.data.ArrayStore({

--- a/interfaces/navigateur/public/js/app/outil/outilImportFichier.js
+++ b/interfaces/navigateur/public/js/app/outil/outilImportFichier.js
@@ -458,7 +458,8 @@ define(['outil', 'aide', 'analyseurGeoJSON', 'vecteur', 'togeojson', 'fileUpload
                                                 visible:true, 
                                                 suppressionPermise:true,
                                                 editable: true,
-                                                geometrieNullePermise: true});
+                                                geometrieNullePermise: true,
+                                                nom: "coucheImportFichier"});
             gestionCouche.ajouterCouche(coucheImportFichier);
         }
         

--- a/interfaces/navigateur/public/js/app/outil/outilZoomPreselection.js
+++ b/interfaces/navigateur/public/js/app/outil/outilZoomPreselection.js
@@ -310,7 +310,7 @@ define(['outil', 'limites','aide', 'style', 'occurence', 'vecteur'], function(Ou
             else{
                 var that = this;
                 var couche = new Vecteur({active: true, suppressionPermise: true, titre:'Géométrie - Outil Zoom',
-                                                        styles:{defaut:regle, select: regleSelectionnee}});
+                                                        styles:{defaut:regle, select: regleSelectionnee}, nom: "coucheZoomRegion"});   
 
                 this.carte.gestionCouches.ajouterCouche(couche);
                 that.ajouterOccurence(couche, occurence);


### PR DESCRIPTION
Ajouter un tag excluExport sur la couche pour qu'elle ne soit pas visible dans l'outil d'export.

Ajouter des noms aux couches de l'outil d'import et l'outil de zoom présélection afin de pouvoir les contrôler avec les métadonnées